### PR TITLE
upgrade to netcore rtm

### DIFF
--- a/src/Slamby.API/Controllers/BaseController.cs
+++ b/src/Slamby.API/Controllers/BaseController.cs
@@ -1,5 +1,5 @@
 ﻿using System.Collections.Generic;
-using Microsoft.AspNet.Mvc;
+using Microsoft.AspNetCore.Mvc;
 using Slamby.Common.Helpers;
 
 namespace Slamby.API.Controllers

--- a/src/Slamby.API/Controllers/DataSetsController.cs
+++ b/src/Slamby.API/Controllers/DataSetsController.cs
@@ -1,7 +1,7 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
-using Microsoft.AspNet.Http;
-using Microsoft.AspNet.Mvc;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
 using Newtonsoft.Json;
 using Slamby.API.Helpers.Swashbuckle;
 using Slamby.API.Resources;
@@ -35,7 +35,7 @@ namespace Slamby.API.Controllers
         {
             var dataSets = dataSetService.Get();
 
-            return new HttpOkObjectResult(dataSets);
+            return new OkObjectResult(dataSets);
         }
 
         [HttpGet("{name}")]
@@ -57,7 +57,7 @@ namespace Slamby.API.Controllers
 
             var dataSet = dataSetService.Get(name);
 
-            return new HttpOkObjectResult(dataSet);
+            return new OkObjectResult(dataSet);
         }
 
         [HttpPost]
@@ -82,18 +82,18 @@ namespace Slamby.API.Controllers
 
             if (dataSet.SampleDocument == null)
             {
-                return HttpBadRequest(ErrorsModel.Create(DataSetResources.SampleDocumentIsEmpty));
+                return BadRequest(ErrorsModel.Create(DataSetResources.SampleDocumentIsEmpty));
             }
 
             var validateResult = documentService.ValidateSampleDocument(dataSet);
             if (validateResult.IsFailure)
             {
-                return HttpBadRequest(ErrorsModel.Create(validateResult.Error));
+                return BadRequest(ErrorsModel.Create(validateResult.Error));
             }
 
             dataSetService.Create(dataSet, withSchema: false);
 
-            return new HttpStatusCodeResult(StatusCodes.Status201Created);
+            return new StatusCodeResult(StatusCodes.Status201Created);
         }
 
         [HttpPost("Schema")]
@@ -118,13 +118,13 @@ namespace Slamby.API.Controllers
 
             if (dataSet.Schema == null)
             {
-                return HttpBadRequest(ErrorsModel.Create(DataSetResources.SchemaIsEmpty));
+                return BadRequest(ErrorsModel.Create(DataSetResources.SchemaIsEmpty));
             }
 
             var validateResult = jsonValidator.Validate(dataSet.Schema);
             if (validateResult.Any())
             {
-                return HttpBadRequest(ErrorsModel.Create(validateResult.Select(error =>
+                return BadRequest(ErrorsModel.Create(validateResult.Select(error =>
                     string.Format(DocumentResources.JsonSchemaValidationError_0, error)
                 )));
             }
@@ -132,12 +132,12 @@ namespace Slamby.API.Controllers
             var validateSchemaResult = documentService.ValidateSchema(dataSet);
             if (validateSchemaResult.IsFailure)
             {
-                return HttpBadRequest(ErrorsModel.Create(validateSchemaResult.Error));
+                return BadRequest(ErrorsModel.Create(validateSchemaResult.Error));
             }
 
             dataSetService.Create(dataSet, withSchema: true);
 
-            return new HttpStatusCodeResult(StatusCodes.Status201Created);
+            return new StatusCodeResult(StatusCodes.Status201Created);
         }
 
         [HttpPut("{existingName}")]
@@ -157,7 +157,7 @@ namespace Slamby.API.Controllers
 
             if (string.CompareOrdinal(existingName, dataSetUpdate.Name) == 0)
             {
-                return new HttpStatusCodeResult(StatusCodes.Status304NotModified);
+                return new StatusCodeResult(StatusCodes.Status304NotModified);
             }
 
             if (!dataSetService.IsExists(existingName))
@@ -174,7 +174,7 @@ namespace Slamby.API.Controllers
 
             dataSetService.Update(existingName, dataSetUpdate.Name);
 
-            return new HttpStatusCodeResult(StatusCodes.Status200OK);
+            return new StatusCodeResult(StatusCodes.Status200OK);
         }
 
         // DELETE api/values/5
@@ -203,7 +203,7 @@ namespace Slamby.API.Controllers
 
             dataSetService.Delete(name);
 
-            return new HttpStatusCodeResult(StatusCodes.Status200OK);
+            return new StatusCodeResult(StatusCodes.Status200OK);
         }
     }
 }

--- a/src/Slamby.API/Controllers/Documents/DocumentsBulkController.cs
+++ b/src/Slamby.API/Controllers/Documents/DocumentsBulkController.cs
@@ -1,5 +1,5 @@
-﻿using Microsoft.AspNet.Http;
-using Microsoft.AspNet.Mvc;
+﻿using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
 using Slamby.API.Filters;
 using Slamby.API.Helpers.Swashbuckle;
 using Slamby.API.Resources;

--- a/src/Slamby.API/Controllers/Documents/DocumentsController.cs
+++ b/src/Slamby.API/Controllers/Documents/DocumentsController.cs
@@ -1,5 +1,5 @@
-﻿using Microsoft.AspNet.Http;
-using Microsoft.AspNet.Mvc;
+﻿using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
 using Slamby.API.Filters;
 using Slamby.API.Helpers.Swashbuckle;
 using Slamby.API.Resources;
@@ -40,7 +40,7 @@ namespace Slamby.API.Controllers
                     string.Format(DocumentResources.DocumentWithId_0_DoesNotFound, id));
             }
 
-            return new HttpOkObjectResult(documentElastic.DocumentObject);
+            return new OkObjectResult(documentElastic.DocumentObject);
         }
 
         [HttpPost]
@@ -53,7 +53,7 @@ namespace Slamby.API.Controllers
             var validateResult = documentService.ValidateDocument(DataSetName, document);
             if (validateResult.IsFailure)
             {
-                return HttpBadRequest(ErrorsModel.Create(validateResult.Error));
+                return BadRequest(ErrorsModel.Create(validateResult.Error));
             }
 
             var id = documentService.GetIdValue(DataSetName, document);
@@ -69,7 +69,7 @@ namespace Slamby.API.Controllers
                 return HttpErrorResult(StatusCodes.Status400BadRequest, indexResult.Error);
             }
 
-            return new HttpStatusCodeResult(StatusCodes.Status201Created);
+            return new StatusCodeResult(StatusCodes.Status201Created);
         }
 
         [HttpPut("{id}")]
@@ -89,7 +89,7 @@ namespace Slamby.API.Controllers
             var validateResult = documentService.ValidateUpdateDocument(DataSetName, document);
             if (validateResult.IsFailure)
             {
-                return HttpBadRequest(ErrorsModel.Create(validateResult.Error));
+                return BadRequest(ErrorsModel.Create(validateResult.Error));
             }
 
             var newId = documentService.GetIdValue(DataSetName, document)?? id;
@@ -99,7 +99,7 @@ namespace Slamby.API.Controllers
                 return HttpErrorResult(StatusCodes.Status400BadRequest, updateResult.Error);
             }
             
-            return new HttpOkObjectResult(documentService.Get(DataSetName, newId)?.DocumentObject);
+            return new OkObjectResult(documentService.Get(DataSetName, newId)?.DocumentObject);
         }
 
         /*
@@ -112,7 +112,7 @@ namespace Slamby.API.Controllers
             var documentElastic = docQuery.Get(id);
             if (documentElastic == null)
             {
-                return new HttpStatusCodeResult(StatusCodes.Status404NotFound);
+                return new StatusCodeResult(StatusCodes.Status404NotFound);
             }
             document.ApplyTo(documentElastic.DocumentObject);
             var newId = ObjectAccessor.Create(document)[DataSet.IdField].ToString(); // ez nem jó a nested fields miatt
@@ -136,7 +136,7 @@ namespace Slamby.API.Controllers
                     string.Format(DocumentResources.DocumentWithId_0_DoesNotFound, id));
             }
             documentService.Delete(DataSetName, id);
-            return new HttpStatusCodeResult(StatusCodes.Status200OK);
+            return new StatusCodeResult(StatusCodes.Status200OK);
         }
     }
 }

--- a/src/Slamby.API/Controllers/Documents/DocumentsCopyController.cs
+++ b/src/Slamby.API/Controllers/Documents/DocumentsCopyController.cs
@@ -1,6 +1,6 @@
 ﻿using System.Linq;
-using Microsoft.AspNet.Http;
-using Microsoft.AspNet.Mvc;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
 using Slamby.API.Filters;
 using Slamby.API.Helpers.Swashbuckle;
 using Slamby.API.Resources;
@@ -56,7 +56,7 @@ namespace Slamby.API.Controllers.Documents
                 return HttpErrorResult(StatusCodes.Status409Conflict, result.Error);
             }
 
-            return new HttpStatusCodeResult(StatusCodes.Status200OK);
+            return new StatusCodeResult(StatusCodes.Status200OK);
         }
     }
 }

--- a/src/Slamby.API/Controllers/Documents/DocumentsFilterController.cs
+++ b/src/Slamby.API/Controllers/Documents/DocumentsFilterController.cs
@@ -1,6 +1,6 @@
 ﻿using System.Linq;
-using Microsoft.AspNet.Http;
-using Microsoft.AspNet.Mvc;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
 using Slamby.API.Filters;
 using Slamby.API.Helpers.Swashbuckle;
 using Slamby.API.Resources;
@@ -44,7 +44,7 @@ namespace Slamby.API.Controllers
             {
                 if (!string.IsNullOrWhiteSpace(scrollId))
                 {
-                    return new HttpOkObjectResult(documentService.GetScrolled(dataSetName, scrollId));
+                    return new OkObjectResult(documentService.GetScrolled(dataSetName, scrollId));
                 }
 
                 if (!string.IsNullOrEmpty(filterSettings.Order?.OrderByField))
@@ -75,7 +75,7 @@ namespace Slamby.API.Controllers
                         filterSettings?.Order?.OrderDirection == OrderDirectionEnum.Desc,
                         filterSettings?.FieldList);
 
-                return new HttpOkObjectResult(paginatedList);
+                return new OkObjectResult(paginatedList);
             }
             catch (ElasticSearchException ex) 
                 when (ex.ServerError.Error.Type == "search_phase_execution_exception" &&

--- a/src/Slamby.API/Controllers/Documents/DocumentsMoveController.cs
+++ b/src/Slamby.API/Controllers/Documents/DocumentsMoveController.cs
@@ -1,6 +1,6 @@
 ﻿using System.Linq;
-using Microsoft.AspNet.Http;
-using Microsoft.AspNet.Mvc;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
 using Slamby.API.Filters;
 using Slamby.API.Helpers.Swashbuckle;
 using Slamby.API.Resources;
@@ -57,7 +57,7 @@ namespace Slamby.API.Controllers.Documents
                 return HttpErrorResult(StatusCodes.Status409Conflict, result.Error);
             }
 
-            return new HttpStatusCodeResult(StatusCodes.Status200OK);
+            return new StatusCodeResult(StatusCodes.Status200OK);
         }
     }
 }

--- a/src/Slamby.API/Controllers/Documents/DocumentsSampleController.cs
+++ b/src/Slamby.API/Controllers/Documents/DocumentsSampleController.cs
@@ -1,5 +1,5 @@
-﻿using Microsoft.AspNet.Http;
-using Microsoft.AspNet.Mvc;
+﻿using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
 using Slamby.API.Filters;
 using Slamby.API.Helpers.Swashbuckle;
 using Slamby.API.Resources;
@@ -50,7 +50,7 @@ namespace Slamby.API.Controllers
                 ? documentService.Sample(dataSetName, sampleSettings.Id, sampleSettings.TagIdList, sampleSettings.Size, sampleSettings?.FieldList) 
                 : documentService.Sample(dataSetName, sampleSettings.Id, sampleSettings.TagIdList, sampleSettings.Percent, sampleSettings?.FieldList);
 
-            return new HttpOkObjectResult(results);
+            return new OkObjectResult(results);
         }
     }
 }

--- a/src/Slamby.API/Controllers/HelperController.cs
+++ b/src/Slamby.API/Controllers/HelperController.cs
@@ -1,8 +1,8 @@
 ﻿using System;
 using System.Globalization;
 using System.Linq;
-using Microsoft.AspNet.Http;
-using Microsoft.AspNet.Mvc;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
 using Slamby.API.Helpers.Swashbuckle;
 using Slamby.API.Resources;
 using Slamby.Common.Helpers;
@@ -32,7 +32,7 @@ namespace Slamby.API.Controllers
         {
             if (fileParser?.Content == null)
             {
-                return HttpBadRequest(
+                return BadRequest(
                     ErrorsModel.Create(
                         string.Format(GlobalResources.TheArgumentCannotBeNull_0, nameof(FileParser.Content))
                         ));
@@ -41,7 +41,7 @@ namespace Slamby.API.Controllers
             var content = fileParser.Content.CleanBase64();
             if (!content.IsBase64())
             {
-                return HttpBadRequest(
+                return BadRequest(
                     ErrorsModel.Create(
                         string.Format(GlobalResources.TheArgument_0_IsNot_1_Type, nameof(FileParser.Content), "base64")
                         ));

--- a/src/Slamby.API/Controllers/ProcessesController.cs
+++ b/src/Slamby.API/Controllers/ProcessesController.cs
@@ -1,7 +1,7 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
-using Microsoft.AspNet.Http;
-using Microsoft.AspNet.Mvc;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
 using Slamby.API.Helpers;
 using Slamby.API.Helpers.Swashbuckle;
 using Slamby.API.Resources;
@@ -36,7 +36,7 @@ namespace Slamby.API.Controllers
                 ? processQuery.GetAll() 
                 : processQuery.GetActives();
 
-            return new HttpOkObjectResult(processes.Select(ModelHelper.ToProcessModel));
+            return new OkObjectResult(processes.Select(ModelHelper.ToProcessModel));
         }
 
         [HttpGet("{id}")]
@@ -52,7 +52,7 @@ namespace Slamby.API.Controllers
                     string.Format(ProcessResources.ProcessWithId_0_DoesNotFound, id));
             }
 
-            return new HttpOkObjectResult(process.ToProcessModel());
+            return new OkObjectResult(process.ToProcessModel());
         }
 
         [HttpPost("{id}/Cancel")]
@@ -74,7 +74,7 @@ namespace Slamby.API.Controllers
                 return new HttpStatusCodeWithErrorResult(StatusCodes.Status400BadRequest, ProcessResources.InvalidStatusOnlyProcessesWithInProgressCanBeCancelled);
             }
             processHandler.Cancel(process.Id);
-            return new HttpStatusCodeResult(StatusCodes.Status202Accepted);
+            return new StatusCodeResult(StatusCodes.Status202Accepted);
         }
     }
 }

--- a/src/Slamby.API/Controllers/Services/ClassifierController.cs
+++ b/src/Slamby.API/Controllers/Services/ClassifierController.cs
@@ -2,8 +2,8 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
-using Microsoft.AspNet.Http;
-using Microsoft.AspNet.Mvc;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
 using Slamby.API.Helpers;
 using Slamby.API.Helpers.Services;
 using Slamby.API.Helpers.Swashbuckle;
@@ -53,7 +53,7 @@ namespace Slamby.API.Controllers
             var service = serviceQuery.Get(id);
             if (service == null)
             {
-                return new HttpStatusCodeResult(StatusCodes.Status404NotFound);
+                return new StatusCodeResult(StatusCodes.Status404NotFound);
             }
             if (service.Type != (int)ServiceTypeEnum.Classifier)
             {
@@ -93,7 +93,7 @@ namespace Slamby.API.Controllers
             respService.ActivateSettings = activateSettings;
             respService.PrepareSettings = prepareSettings;
 
-            return new HttpOkObjectResult(respService);
+            return new OkObjectResult(respService);
         }
 
         [HttpPost("{id}/Prepare")]
@@ -291,7 +291,7 @@ namespace Slamby.API.Controllers
             service.Status = (int)ServiceStatusEnum.Prepared;
             serviceQuery.Update(service.Id, service);
 
-            return new HttpOkResult();
+            return new OkResult();
         }
 
         [HttpPost("{id}/Recommend")]
@@ -346,7 +346,7 @@ namespace Slamby.API.Controllers
                 Tag = request.NeedTagInResult ? GlobalStore.ActivatedClassifiers.Get(id).ClassifiersTags[r.Key] : null,
                 IsEmphasized = request.UseEmphasizing && emphasizedCategoriesDictionary.ContainsKey(r.Key)
             });
-            return new HttpOkObjectResult(results);
+            return new OkObjectResult(results);
         }
 
         [HttpPost("{id}/ExportDictionaries")]

--- a/src/Slamby.API/Controllers/Services/PrcController.cs
+++ b/src/Slamby.API/Controllers/Services/PrcController.cs
@@ -2,8 +2,8 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
-using Microsoft.AspNet.Http;
-using Microsoft.AspNet.Mvc;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
 using Slamby.API.Helpers;
 using Slamby.API.Helpers.Services;
 using Slamby.API.Helpers.Swashbuckle;
@@ -61,7 +61,7 @@ namespace Slamby.API.Controllers.Services
             var service = serviceQuery.Get(id);
             if (service == null)
             {
-                return new HttpStatusCodeResult(StatusCodes.Status404NotFound);
+                return new StatusCodeResult(StatusCodes.Status404NotFound);
             }
             if (service.Type != (int)ServiceTypeEnum.Prc)
             {
@@ -112,7 +112,7 @@ namespace Slamby.API.Controllers.Services
             respService.PrepareSettings = prepareSettings;
             respService.IndexSettings = indexSettings;
 
-            return new HttpOkObjectResult(respService);
+            return new OkObjectResult(respService);
         }
 
         [HttpPost("{id}/Prepare")]
@@ -273,7 +273,7 @@ namespace Slamby.API.Controllers.Services
             service.Status = (int)ServiceStatusEnum.Prepared;
             serviceQuery.Update(service.Id, service);
 
-            return new HttpOkResult();
+            return new OkResult();
         }
 
         [HttpPost("{id}/Keywords")]
@@ -325,7 +325,7 @@ namespace Slamby.API.Controllers.Services
                 var avg = baseDic.Sum(d => d.Value) / baseDic.Count;
                 baseDic.RemoveAll(d => d.Value < avg);
             }
-            return new HttpOkObjectResult(baseDic.Select(d => new PrcKeywordsResult { Word = d.Key, Score = d.Value }));
+            return new OkObjectResult(baseDic.Select(d => new PrcKeywordsResult { Word = d.Key, Score = d.Value }));
         }
 
         [HttpPost("{id}/Recommend")]
@@ -335,7 +335,7 @@ namespace Slamby.API.Controllers.Services
         [SwaggerResponse(StatusCodes.Status406NotAcceptable)]
         public IActionResult Recommend(string id, [FromBody]PrcRecommendationRequest request)
         {
-            if (request == null) return new HttpStatusCodeResult(StatusCodes.Status400BadRequest);
+            if (request == null) return new StatusCodeResult(StatusCodes.Status400BadRequest);
             // If Id is Alias, translate to Id
             if (GlobalStore.ServiceAliases.IsExist(id))
             {
@@ -374,7 +374,7 @@ namespace Slamby.API.Controllers.Services
                     allResults.Add(new KeyValuePair<string, double>(scorerKvp.Key, score));
                 }
                 var resultsList = allResults.Where(r => r.Value > 0).OrderByDescending(r => r.Value).ToList();
-                if (resultsList.Count == 0) return new HttpOkObjectResult(new List<PrcRecommendationResult>());
+                if (resultsList.Count == 0) return new OkObjectResult(new List<PrcRecommendationResult>());
                 tagId = resultsList.First().Key;
             }
             
@@ -421,7 +421,7 @@ namespace Slamby.API.Controllers.Services
 
             if (baseScore == 0 || globalScore == 0)
             {
-                return new HttpOkObjectResult(results);
+                return new OkObjectResult(results);
             }
 
             var query = request.Filter != null ? request.Filter.Query : string.Empty;
@@ -500,7 +500,7 @@ namespace Slamby.API.Controllers.Services
                 ? resultDic.Select(r => documentElastics.First(d => d.Id == r.Key)).ToDictionary(d => d.Id, d => d) 
                 : null;
 
-            return new HttpOkObjectResult(resultDic.Select(kvp => new PrcRecommendationResult {
+            return new OkObjectResult(resultDic.Select(kvp => new PrcRecommendationResult {
                 DocumentId = kvp.Key,
                 Score = kvp.Value,
                 Document = request.NeedDocumentInResult ? docsDic[kvp.Key].DocumentObject : null
@@ -621,7 +621,7 @@ namespace Slamby.API.Controllers.Services
         [SwaggerResponse(StatusCodes.Status400BadRequest)]
         public IActionResult RecommendById(string id, [FromBody]PrcRecommendationByIdRequest request)
         {
-            if (request == null) return new HttpStatusCodeResult(StatusCodes.Status400BadRequest);
+            if (request == null) return new StatusCodeResult(StatusCodes.Status400BadRequest);
             // If Id is Alias, translate to Id
             if (GlobalStore.ServiceAliases.IsExist(id))
             {
@@ -640,7 +640,7 @@ namespace Slamby.API.Controllers.Services
             var prcSettings = GlobalStore.ActivatedPrcs.Get(id).PrcsSettings;
             var result = prcIndexHandler.RecommendById(id, prcSettings, request);
 
-            return new HttpOkObjectResult(result);
+            return new OkObjectResult(result);
         }
 
         [HttpPost("{id}/ExportDictionaries")]

--- a/src/Slamby.API/Controllers/Services/ServicesController.cs
+++ b/src/Slamby.API/Controllers/Services/ServicesController.cs
@@ -1,8 +1,8 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using Microsoft.AspNet.Http;
-using Microsoft.AspNet.Mvc;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
 using Slamby.API.Helpers.Services;
 using Slamby.Elastic.Models;
 using Slamby.Elastic.Queries;
@@ -44,7 +44,7 @@ namespace Slamby.API.Controllers
                 return service;
             });
 
-            return new HttpOkObjectResult(services);
+            return new OkObjectResult(services);
         }
 
         [HttpGet("{id}", Name = "GetService")]
@@ -56,11 +56,11 @@ namespace Slamby.API.Controllers
             var serviceElastic = serviceQuery.Get(id);
             if (serviceElastic == null)
             {
-                return new HttpStatusCodeResult(StatusCodes.Status404NotFound);
+                return new StatusCodeResult(StatusCodes.Status404NotFound);
             }
             var service = serviceElastic.ToServiceModel<Service>();
             service.ActualProcessId = serviceElastic.ProcessIdList.FirstOrDefault(pid => GlobalStore.Processes.IsExist(pid));
-            return new HttpOkObjectResult(service);
+            return new OkObjectResult(service);
         }
 
         [HttpPost]
@@ -71,15 +71,15 @@ namespace Slamby.API.Controllers
         {
             if (!string.IsNullOrEmpty(service.Id))
             {
-                return new HttpStatusCodeResult(StatusCodes.Status400BadRequest);
+                return new StatusCodeResult(StatusCodes.Status400BadRequest);
             }
             if (string.IsNullOrEmpty(service.Name))
             {
-                return new HttpStatusCodeResult(StatusCodes.Status400BadRequest);
+                return new StatusCodeResult(StatusCodes.Status400BadRequest);
             }
             if (!Enum.IsDefined(typeof(ServiceTypeEnum), service.Type))
             {
-                return new HttpStatusCodeResult(StatusCodes.Status400BadRequest);
+                return new StatusCodeResult(StatusCodes.Status400BadRequest);
             }
 
             var serviceElastic = ServiceElastic.Create(service.Name, service.Type, service.Alias, service.Description);
@@ -114,7 +114,7 @@ namespace Slamby.API.Controllers
             var serviceElastic = serviceQuery.Get(id);
             if (serviceElastic == null)
             {
-                return new HttpStatusCodeResult(StatusCodes.Status404NotFound);
+                return new StatusCodeResult(StatusCodes.Status404NotFound);
             }
 
             if (!string.IsNullOrEmpty(service.Name))
@@ -135,7 +135,7 @@ namespace Slamby.API.Controllers
 
             GlobalStore.ServiceAliases.Set(serviceElastic.Alias, serviceElastic.Id);
 
-            return new HttpStatusCodeResult(StatusCodes.Status200OK);
+            return new StatusCodeResult(StatusCodes.Status200OK);
         }
 
         [HttpDelete("{id}")]
@@ -147,7 +147,7 @@ namespace Slamby.API.Controllers
             var service = serviceQuery.Get(id);
             if (service == null)
             {
-                return new HttpStatusCodeResult(StatusCodes.Status404NotFound);
+                return new StatusCodeResult(StatusCodes.Status404NotFound);
             }
 
             switch (service.Type)
@@ -173,7 +173,7 @@ namespace Slamby.API.Controllers
                 processQuery.Delete(service.ProcessIdList);
             }
 
-            return new HttpStatusCodeResult(StatusCodes.Status200OK);
+            return new StatusCodeResult(StatusCodes.Status200OK);
         }
     }
 }

--- a/src/Slamby.API/Controllers/StatusController.cs
+++ b/src/Slamby.API/Controllers/StatusController.cs
@@ -1,5 +1,5 @@
-﻿using Microsoft.AspNet.Http;
-using Microsoft.AspNet.Mvc;
+﻿using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
 using Slamby.API.Helpers.Swashbuckle;
 using Slamby.Common.Services;
 using Slamby.SDK.Net.Models;

--- a/src/Slamby.API/Controllers/Tags/TagsBulkController.cs
+++ b/src/Slamby.API/Controllers/Tags/TagsBulkController.cs
@@ -1,6 +1,6 @@
 ﻿using System.Linq;
-using Microsoft.AspNet.Http;
-using Microsoft.AspNet.Mvc;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
 using Slamby.API.Filters;
 using Slamby.API.Helpers.Swashbuckle;
 using Slamby.API.Resources;

--- a/src/Slamby.API/Controllers/Tags/TagsCleanDocumentsController.cs
+++ b/src/Slamby.API/Controllers/Tags/TagsCleanDocumentsController.cs
@@ -1,6 +1,6 @@
 ﻿using System.Linq;
-using Microsoft.AspNet.Http;
-using Microsoft.AspNet.Mvc;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
 using Slamby.API.Filters;
 using Slamby.API.Helpers.Swashbuckle;
 using Slamby.API.Services.Interfaces;
@@ -35,7 +35,7 @@ namespace Slamby.API.Controllers
             var tagIds = tagQuery.GetAll().Items.Select(i => i.Id).ToList();
             documentService.CleanDocuments(dataSetSelector.DataSetName, tagIds);
 
-            return new HttpStatusCodeResult(StatusCodes.Status200OK);
+            return new StatusCodeResult(StatusCodes.Status200OK);
         }
     }
 }

--- a/src/Slamby.API/Controllers/Tags/TagsController.cs
+++ b/src/Slamby.API/Controllers/Tags/TagsController.cs
@@ -1,6 +1,6 @@
 ﻿using System.Collections.Generic;
-using Microsoft.AspNet.Http;
-using Microsoft.AspNet.Mvc;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
 using Slamby.API.Filters;
 using Slamby.API.Helpers.Swashbuckle;
 using Slamby.API.Resources;
@@ -34,7 +34,7 @@ namespace Slamby.API.Controllers
         {
             var tags = tagService.GetTagModels(DataSetName, withDetails);
 
-            return new HttpOkObjectResult(tags);
+            return new OkObjectResult(tags);
         }
 
         [HttpGet("{id}", Name = "GetTag")]
@@ -51,7 +51,7 @@ namespace Slamby.API.Controllers
 
             var tag = tagService.GetTagModel(DataSetName, id, withDetails);
 
-            return new HttpOkObjectResult(tag);
+            return new OkObjectResult(tag);
         }
 
         [HttpPost]
@@ -128,7 +128,7 @@ namespace Slamby.API.Controllers
 
             tagService.Update(DataSetName, id, tag);
 
-            return new HttpOkResult();
+            return new OkResult();
         }
 
         // DELETE api/values/5
@@ -155,7 +155,7 @@ namespace Slamby.API.Controllers
 
             tagService.Delete(DataSetName, id, force, cleanDocuments);
 
-            return new HttpOkResult();
+            return new OkResult();
         }
     }
 }

--- a/src/Slamby.API/Controllers/Tags/TagsExportWordsController.cs
+++ b/src/Slamby.API/Controllers/Tags/TagsExportWordsController.cs
@@ -1,7 +1,7 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
-using Microsoft.AspNet.Http;
-using Microsoft.AspNet.Mvc;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
 using Slamby.API.Filters;
 using Slamby.API.Helpers;
 using Slamby.API.Helpers.Swashbuckle;

--- a/src/Slamby.API/Filters/DataSetNameFilter.cs
+++ b/src/Slamby.API/Filters/DataSetNameFilter.cs
@@ -1,6 +1,6 @@
 ﻿using System.Collections.Generic;
-using Microsoft.AspNet.Mvc;
-using Microsoft.AspNet.Mvc.Filters;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Filters;
 using Slamby.API.Services.Interfaces;
 using Slamby.SDK.Net.Models;
 using static Slamby.API.Resources.GlobalResources;

--- a/src/Slamby.API/Filters/GlobalExceptionFilter.cs
+++ b/src/Slamby.API/Filters/GlobalExceptionFilter.cs
@@ -1,6 +1,6 @@
 ﻿using System;
-using Microsoft.AspNet.Mvc;
-using Microsoft.AspNet.Mvc.Filters;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Filters;
 using Microsoft.Extensions.Logging;
 using Slamby.SDK.Net.Models;
 using System.IO;

--- a/src/Slamby.API/Filters/ModelValidationFilter.cs
+++ b/src/Slamby.API/Filters/ModelValidationFilter.cs
@@ -1,8 +1,8 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
-using Microsoft.AspNet.Mvc;
-using Microsoft.AspNet.Mvc.Controllers;
-using Microsoft.AspNet.Mvc.Filters;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Controllers;
+using Microsoft.AspNetCore.Mvc.Filters;
 using Slamby.API.Resources;
 using Slamby.SDK.Net.Models;
 

--- a/src/Slamby.API/Filters/SdkVersionFilter.cs
+++ b/src/Slamby.API/Filters/SdkVersionFilter.cs
@@ -1,5 +1,5 @@
 ﻿using System.Linq;
-using Microsoft.AspNet.Mvc.Filters;
+using Microsoft.AspNetCore.Mvc.Filters;
 using Slamby.API.Resources;
 using Slamby.Common.Config;
 using Slamby.SDK.Net;
@@ -25,7 +25,7 @@ namespace Slamby.API.Filters
 
                 if (!string.Equals(sdkVersion, apiVersion))
                 {
-                    context.Result = new Microsoft.AspNet.Mvc.BadRequestObjectResult(
+                    context.Result = new Microsoft.AspNetCore.Mvc.BadRequestObjectResult(
                         ErrorsModel.Create(string.Format(GlobalResources.SdkApiVersionMismatch, sdkVersion, apiVersion))
                     );
 

--- a/src/Slamby.API/Filters/ThrottleActionFilter.cs
+++ b/src/Slamby.API/Filters/ThrottleActionFilter.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.AspNet.Mvc.Filters;
+﻿using Microsoft.AspNetCore.Mvc.Filters;
 using Slamby.API.Helpers;
 using Slamby.API.Services;
 using Slamby.Common.Config;

--- a/src/Slamby.API/Helpers/ApplicationBuilderHelpers.cs
+++ b/src/Slamby.API/Helpers/ApplicationBuilderHelpers.cs
@@ -1,8 +1,8 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Net;
-using Microsoft.AspNet.Builder;
-using Microsoft.AspNet.Http;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Logging;
 using Newtonsoft.Json;
 using Slamby.SDK.Net.Models;

--- a/src/Slamby.API/Helpers/BulkResponseHelper.cs
+++ b/src/Slamby.API/Helpers/BulkResponseHelper.cs
@@ -1,6 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
-using Microsoft.AspNet.Http;
+using Microsoft.AspNetCore.Http;
 using Slamby.SDK.Net.Models;
 using Slamby.Elastic.Models;
 

--- a/src/Slamby.API/Helpers/HostUrlHelper.cs
+++ b/src/Slamby.API/Helpers/HostUrlHelper.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 using System.Linq;
-using Microsoft.AspNet.Http;
+using Microsoft.AspNetCore.Http;
 
 namespace Slamby.API.Helpers
 {

--- a/src/Slamby.API/Helpers/RequestLoggerHelper.cs
+++ b/src/Slamby.API/Helpers/RequestLoggerHelper.cs
@@ -1,6 +1,7 @@
 ﻿using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Features;
 using Microsoft.AspNetCore.WebUtilities;
+using Microsoft.Extensions.Primitives;
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -13,7 +14,7 @@ namespace Slamby.API.Helpers
     {
         public static string FormatHeaders(IHeaderDictionary headers)
         {
-            return string.Join("\n", headers.Select(h => string.Format(h.Key + "|" + string.Join(" ", h.Value))));
+            return string.Join("\n", headers.Select(h => string.Format(h.Key + "|" + (h.Value != StringValues.Empty ? string.Join(" ", h.Value) : ""))));
         }
 
         public static string Format(HttpRequest request, string requestId, Stream bodyStream, string baseUrlPrefix)

--- a/src/Slamby.API/Helpers/RequestLoggerHelper.cs
+++ b/src/Slamby.API/Helpers/RequestLoggerHelper.cs
@@ -1,6 +1,6 @@
-﻿using Microsoft.AspNet.Http;
-using Microsoft.AspNet.Http.Features;
-using Microsoft.AspNet.WebUtilities;
+﻿using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.Features;
+using Microsoft.AspNetCore.WebUtilities;
 using System;
 using System.Collections.Generic;
 using System.IO;

--- a/src/Slamby.API/Helpers/Services/PrcIndexServiceHandler.cs
+++ b/src/Slamby.API/Helpers/Services/PrcIndexServiceHandler.cs
@@ -96,7 +96,7 @@ namespace Slamby.API.Helpers.Services
                         return;
                     }
 
-                    logger.LogVerbose($"{logPrefix} preparing Tag: `{tagId}`");
+                    logger.LogTrace($"{logPrefix} preparing Tag: `{tagId}`");
 
                     var globalSubset = GlobalStore.ActivatedPrcs.Get(prcSettings.ServiceId).PrcSubsets[tagId];
                     if (globalSubset.WordsWithOccurences == null)
@@ -127,7 +127,7 @@ namespace Slamby.API.Helpers.Services
 
                         try
                         {
-                            logger.LogVerbose($"{logPrefix} preparing Document: `{documentId}`/`{tagId}`");
+                            logger.LogTrace($"{logPrefix} preparing Document: `{documentId}`/`{tagId}`");
 
                             // kiszámoljuk az aktuális doksi base dictionary - jét
                             var scorer = GetScorer(globalSubset, wwoDocuments[documentId], cleanedTextDocuments[documentId], GlobalStore.ActivatedPrcs.Get(prcSettings.ServiceId).PrcScorers[tagId]);
@@ -157,7 +157,7 @@ namespace Slamby.API.Helpers.Services
                         }
                         finally
                         {
-                            logger.LogVerbose($"{logPrefix} prepared Document: `{documentId}`/`{tagId}`");
+                            logger.LogTrace($"{logPrefix} prepared Document: `{documentId}`/`{tagId}`");
 
                             allDocProgress.Step();
                             var value = docProgress.Step();
@@ -168,8 +168,8 @@ namespace Slamby.API.Helpers.Services
                                     processHandler.Changed(processId, allDocProgress.Percent.Round(6));
                                 }
 
-                                logger.LogVerbose($"{logPrefix} progress {docProgress} in `{tagId}`");
-                                logger.LogVerbose($"{logPrefix} total progress is {allDocProgress}");
+                                logger.LogTrace($"{logPrefix} progress {docProgress} in `{tagId}`");
+                                logger.LogTrace($"{logPrefix} total progress is {allDocProgress}");
                             }
                             if (value % 1000 == 0)
                             {
@@ -269,7 +269,7 @@ namespace Slamby.API.Helpers.Services
                         }
                         try
                         {
-                            logger.LogVerbose($"{logPrefix} preparing Document: `{documentId}`/`{tagId}`");
+                            logger.LogTrace($"{logPrefix} preparing Document: `{documentId}`/`{tagId}`");
 
                             var scorer = GetScorer(globalSubset, wwoDocuments[documentId], cleanedTextDocuments[documentId], GlobalStore.ActivatedPrcs.Get(prcSettings.ServiceId).PrcScorers[tagId]);
                             if (scorer == null)
@@ -341,7 +341,7 @@ namespace Slamby.API.Helpers.Services
                         }
                         finally
                         {
-                            logger.LogVerbose($"{logPrefix} prepared Document: `{documentId}`/`{tagId}`");
+                            logger.LogTrace($"{logPrefix} prepared Document: `{documentId}`/`{tagId}`");
                         }
                     });
 

--- a/src/Slamby.API/Helpers/Swashbuckle/ApplySwaggerResponseFilterAttributesOperationFilter.cs
+++ b/src/Slamby.API/Helpers/Swashbuckle/ApplySwaggerResponseFilterAttributesOperationFilter.cs
@@ -1,0 +1,29 @@
+﻿using Swashbuckle.SwaggerGen.Generator;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Swashbuckle.Swagger.Model;
+
+namespace Slamby.API.Helpers.Swashbuckle
+{
+    public class ApplySwaggerResponseFilterAttributesOperationFilter : IOperationFilter
+    {
+        public void Apply(Operation operation, OperationFilterContext context)
+        {
+            var controllerAttributes = context.ApiDescription.GetControllerAttributes().OfType<SwaggerResponseRemoveDefaultsAttribute>();
+
+            foreach (var attribute in controllerAttributes)
+            {
+                attribute.Apply(operation, context);
+            }
+
+            var operationAttributes = context.ApiDescription.GetActionAttributes().OfType<SwaggerResponseAttribute>();
+
+            foreach (var attribute in operationAttributes)
+            {
+                attribute.Apply(operation, context);
+            }
+        }
+    }
+}

--- a/src/Slamby.API/Helpers/Swashbuckle/RegexSchemaFilter.cs
+++ b/src/Slamby.API/Helpers/Swashbuckle/RegexSchemaFilter.cs
@@ -1,4 +1,6 @@
-﻿using System.Linq;
+﻿using System;
+using System.Linq;
+using Swashbuckle.Swagger.Model;
 using Swashbuckle.SwaggerGen.Generator;
 
 namespace Slamby.API.Helpers.Swashbuckle
@@ -7,9 +9,9 @@ namespace Slamby.API.Helpers.Swashbuckle
     /// Regex pattern replacer
     /// Swagger likes Perl sytle regex pattern
     /// </summary>
-    public class RegexModelFilter : IModelFilter
+    public class RegexSchemaFilter : ISchemaFilter
     {
-        public void Apply(Schema model, ModelFilterContext context)
+        public void Apply(Schema model, SchemaFilterContext context)
         {
             foreach (var prop in model.Properties.Where(p => !string.IsNullOrEmpty(p.Value.Pattern)))
             {

--- a/src/Slamby.API/Helpers/Swashbuckle/RegexSchemaFilter.cs
+++ b/src/Slamby.API/Helpers/Swashbuckle/RegexSchemaFilter.cs
@@ -13,6 +13,9 @@ namespace Slamby.API.Helpers.Swashbuckle
     {
         public void Apply(Schema model, SchemaFilterContext context)
         {
+            //TODO: check this
+            if (model.Properties == null)
+                return;
             foreach (var prop in model.Properties.Where(p => !string.IsNullOrEmpty(p.Value.Pattern)))
             {
                 prop.Value.Pattern = $"/{prop.Value.Pattern}/";

--- a/src/Slamby.API/Helpers/Swashbuckle/SwaggerApplyBasicAuthFilter.cs
+++ b/src/Slamby.API/Helpers/Swashbuckle/SwaggerApplyBasicAuthFilter.cs
@@ -1,4 +1,6 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
+using Swashbuckle.Swagger.Model;
 using Swashbuckle.SwaggerGen.Generator;
 
 namespace Slamby.API.Helpers.Swashbuckle
@@ -24,7 +26,7 @@ namespace Slamby.API.Helpers.Swashbuckle
             operation.Parameters.Add(new NonBodyParameter()
             {
                 Name = "Slamby",
-                In =  "header",
+                In = "header",
                 Description = "Http authentication. Ex: Authorization: Slamby <api_secret>",
                 Type = "string",
                 Required = true

--- a/src/Slamby.API/Helpers/Swashbuckle/SwaggerHelper.cs
+++ b/src/Slamby.API/Helpers/Swashbuckle/SwaggerHelper.cs
@@ -1,5 +1,5 @@
 ﻿using System.Linq;
-using Microsoft.AspNet.Mvc.ApiExplorer;
+using Microsoft.AspNetCore.Mvc.ApiExplorer;
 using Swashbuckle.SwaggerGen.Generator;
 
 namespace Slamby.API.Helpers.Swashbuckle

--- a/src/Slamby.API/Helpers/Swashbuckle/SwaggerResponseAttribute.cs
+++ b/src/Slamby.API/Helpers/Swashbuckle/SwaggerResponseAttribute.cs
@@ -1,0 +1,66 @@
+﻿using Swashbuckle.SwaggerGen.Annotations;
+using Swashbuckle.SwaggerGen.Generator;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Threading.Tasks;
+using Swashbuckle.Swagger.Model;
+
+namespace Slamby.API.Helpers.Swashbuckle
+{
+    [AttributeUsage(AttributeTargets.Method, AllowMultiple = true)]
+    public class SwaggerResponseAttribute : Attribute, IOperationFilter
+    {
+        public SwaggerResponseAttribute(HttpStatusCode statusCode)
+            :this((int)statusCode)
+        {
+        }
+
+        public SwaggerResponseAttribute(HttpStatusCode statusCode, string description = null, Type type = null)
+            : this(statusCode)
+        {
+            Description = description;
+            Type = type;
+        }
+
+        public SwaggerResponseAttribute(int statusCode)
+        {
+            StatusCode = statusCode;
+        }
+
+        public SwaggerResponseAttribute(int statusCode, string description = null, Type type = null)
+            : this(statusCode)
+        {
+            Description = description;
+            Type = type;
+        }
+
+        public int StatusCode { get; private set; }
+
+        public string Description { get; set; }
+
+        public Type Type { get; set; }
+
+        public void Apply(Operation operation, OperationFilterContext context)
+        {
+            var statusCode = StatusCode.ToString();
+
+            operation.Responses[statusCode] = new Response
+            {
+                Description = Description ?? InferDescriptionFrom(statusCode),
+                Schema = (Type != null) ? context.SchemaRegistry.GetOrRegister(Type) : null
+            };
+        }
+
+        private string InferDescriptionFrom(string statusCode)
+        {
+            HttpStatusCode enumValue;
+            if (Enum.TryParse(statusCode, true, out enumValue))
+            {
+                return enumValue.ToString();
+            }
+            return null;
+        }
+    }
+}

--- a/src/Slamby.API/Helpers/Swashbuckle/SwaggerResponseRemoveDefaultsAttribute.cs
+++ b/src/Slamby.API/Helpers/Swashbuckle/SwaggerResponseRemoveDefaultsAttribute.cs
@@ -1,0 +1,18 @@
+﻿using Swashbuckle.SwaggerGen.Generator;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Swashbuckle.Swagger.Model;
+
+namespace Slamby.API.Helpers.Swashbuckle
+{
+    [AttributeUsage(AttributeTargets.Class, AllowMultiple = false)]
+    public class SwaggerResponseRemoveDefaultsAttribute : Attribute, IOperationFilter
+    {
+        public void Apply(Operation operation, OperationFilterContext context)
+        {
+            operation.Responses.Clear();
+        }
+    }
+}

--- a/src/Slamby.API/Helpers/Swashbuckle/SwaggerSchemaDocumentFilter.cs
+++ b/src/Slamby.API/Helpers/Swashbuckle/SwaggerSchemaDocumentFilter.cs
@@ -1,4 +1,6 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
+using Swashbuckle.Swagger.Model;
 using Swashbuckle.SwaggerGen.Generator;
 
 namespace Slamby.API.Helpers.Swashbuckle

--- a/src/Slamby.API/Middlewares/ApiHeaderAuthenticationMiddleware.cs
+++ b/src/Slamby.API/Middlewares/ApiHeaderAuthenticationMiddleware.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Threading.Tasks;
-using Microsoft.AspNet.Builder;
-using Microsoft.AspNet.Http;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
 using Slamby.Common.Config;
 using Slamby.SDK.Net;
 

--- a/src/Slamby.API/Middlewares/ApiHeaderVersionMiddleware.cs
+++ b/src/Slamby.API/Middlewares/ApiHeaderVersionMiddleware.cs
@@ -1,6 +1,6 @@
 ﻿using System.Threading.Tasks;
-using Microsoft.AspNet.Builder;
-using Microsoft.AspNet.Http;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
 using Slamby.Common.Config;
 using Slamby.SDK.Net;
 

--- a/src/Slamby.API/Middlewares/ElapsedTimeMiddleware.cs
+++ b/src/Slamby.API/Middlewares/ElapsedTimeMiddleware.cs
@@ -1,7 +1,7 @@
 ﻿using System.Diagnostics;
 using System.Threading.Tasks;
-using Microsoft.AspNet.Builder;
-using Microsoft.AspNet.Http;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
 
 namespace Slamby.API.Middlewares
 {

--- a/src/Slamby.API/Middlewares/ElmSecurityMiddleware.cs
+++ b/src/Slamby.API/Middlewares/ElmSecurityMiddleware.cs
@@ -2,10 +2,10 @@
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
-using Microsoft.AspNet.Builder;
-using Microsoft.AspNet.Http;
-using Microsoft.AspNet.Server.Kestrel.Http;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
 using Slamby.Common.Config;
+using Microsoft.AspNetCore.Server.Kestrel.Internal.Http;
 
 namespace Slamby.API.Middlewares
 {

--- a/src/Slamby.API/Middlewares/ElmStyleUrlFixMiddleware.cs
+++ b/src/Slamby.API/Middlewares/ElmStyleUrlFixMiddleware.cs
@@ -1,7 +1,7 @@
 ﻿using System.IO;
 using System.Threading.Tasks;
-using Microsoft.AspNet.Builder;
-using Microsoft.AspNet.Http;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
 
 namespace Slamby.API.Middlewares
 {

--- a/src/Slamby.API/Middlewares/GzipMiddleware.cs
+++ b/src/Slamby.API/Middlewares/GzipMiddleware.cs
@@ -1,8 +1,8 @@
 ﻿using System.IO;
 using System.IO.Compression;
 using System.Threading.Tasks;
-using Microsoft.AspNet.Builder;
-using Microsoft.AspNet.Http;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
 using Microsoft.Net.Http.Headers;
 using Slamby.Common.Helpers;
 

--- a/src/Slamby.API/Middlewares/MiddlewareExtensions.cs
+++ b/src/Slamby.API/Middlewares/MiddlewareExtensions.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.AspNet.Builder;
+﻿using Microsoft.AspNetCore.Builder;
 
 namespace Slamby.API.Middlewares
 {

--- a/src/Slamby.API/Middlewares/NotFoundMiddleware.cs
+++ b/src/Slamby.API/Middlewares/NotFoundMiddleware.cs
@@ -1,6 +1,6 @@
 ﻿using System.Threading.Tasks;
-using Microsoft.AspNet.Builder;
-using Microsoft.AspNet.Http;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
 using Newtonsoft.Json;
 using Slamby.SDK.Net.Models;
 

--- a/src/Slamby.API/Middlewares/RequestLoggerMiddleware.cs
+++ b/src/Slamby.API/Middlewares/RequestLoggerMiddleware.cs
@@ -2,10 +2,10 @@
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
-using Microsoft.AspNet.Builder;
-using Microsoft.AspNet.Http;
-using Microsoft.AspNet.Http.Features;
-using Microsoft.AspNet.WebUtilities;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.Features;
+using Microsoft.AspNetCore.WebUtilities;
 using Microsoft.Extensions.Logging;
 using Slamby.API.Helpers;
 using Slamby.Common.Config;
@@ -49,7 +49,7 @@ namespace Slamby.API.Middlewares
             await context.Request.Body.CopyToAsync(requestBodyStream);
 
             requestBodyStream.Seek(0, SeekOrigin.Begin);
-            _logger.LogVerbose(RequestLoggerHelper.Format(context.Request, requestId, requestBodyStream, siteConfig.BaseUrlPrefix));
+            _logger.LogTrace(RequestLoggerHelper.Format(context.Request, requestId, requestBodyStream, siteConfig.BaseUrlPrefix));
             requestBodyStream.Seek(0, SeekOrigin.Begin);
 
             context.Request.Body = requestBodyStream;
@@ -65,7 +65,7 @@ namespace Slamby.API.Middlewares
             context.Request.Body = originalRequestBody;
 
             responseBodyStream.Seek(0, SeekOrigin.Begin);
-            _logger.LogVerbose(RequestLoggerHelper.Format(context.Response, requestId, responseBodyStream));
+            _logger.LogTrace(RequestLoggerHelper.Format(context.Response, requestId, responseBodyStream));
             responseBodyStream.Seek(0, SeekOrigin.Begin);
 
             await responseBodyStream.CopyToAsync(bodyStream);
@@ -73,12 +73,12 @@ namespace Slamby.API.Middlewares
 
         private async Task LogWithoutContent(HttpContext context, string requestId)
         {
-            _logger.LogVerbose(RequestLoggerHelper.Format(context.Request, requestId, null, siteConfig.BaseUrlPrefix));
+            _logger.LogTrace(RequestLoggerHelper.Format(context.Request, requestId, null, siteConfig.BaseUrlPrefix));
 
             // Call next Middleware
             await next(context);
 
-            _logger.LogVerbose(RequestLoggerHelper.Format(context.Response, requestId, null));
+            _logger.LogTrace(RequestLoggerHelper.Format(context.Response, requestId, null));
         }
 
         

--- a/src/Slamby.API/Middlewares/RequestSizeLimitMiddleware.cs
+++ b/src/Slamby.API/Middlewares/RequestSizeLimitMiddleware.cs
@@ -1,8 +1,8 @@
 ﻿using System.Threading.Tasks;
-using Microsoft.AspNet.Builder;
-using Microsoft.AspNet.Http;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
 using static Slamby.API.Resources.GlobalResources;
-using Microsoft.AspNet.Mvc;
+using Microsoft.AspNetCore.Mvc;
 using System.Collections.Generic;
 using Slamby.Common.Services;
 

--- a/src/Slamby.API/Program.cs
+++ b/src/Slamby.API/Program.cs
@@ -1,0 +1,28 @@
+﻿using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.Configuration;
+using System.IO;
+
+namespace Slamby.API
+{
+    public class Program
+    {
+        public static void Main(string[] args)
+        {
+            var config = new ConfigurationBuilder()
+                .AddCommandLine(args)
+                .AddEnvironmentVariables(prefix: "ASPNETCORE_")
+                .Build();
+
+            var host = new WebHostBuilder()
+                .UseConfiguration(config)
+                .UseKestrel()
+                .UseContentRoot(Directory.GetCurrentDirectory())
+                .UseIISIntegration()
+                .UseStartup<Startup>()
+                .Build();
+
+            host.Run();
+        }
+    }
+}
+

--- a/src/Slamby.API/Services/DBUpdateService.cs
+++ b/src/Slamby.API/Services/DBUpdateService.cs
@@ -143,21 +143,31 @@ namespace Slamby.API.Services
 
                 var propertiesElastic = hits[indexName].Source;
 
+#pragma warning disable CS0618 // Type or member is obsolete
                 if (propertiesElastic.DBVersion < Constants.DBVersion)
+#pragma warning restore CS0618 // Type or member is obsolete
                 {
                     logger.LogInformation("Elasticsearch database is not at the latest version");
 
                     // Update from 1 -> 2
+#pragma warning disable CS0618 // Type or member is obsolete
                     if (propertiesElastic.DBVersion == 1)
+#pragma warning restore CS0618 // Type or member is obsolete
                     {
+#pragma warning disable CS0618 // Type or member is obsolete
                         logger.LogInformation($"Updating from version {propertiesElastic.DBVersion}...");
+#pragma warning restore CS0618 // Type or member is obsolete
                         propertiesElastic.Name = string.Empty;
+#pragma warning disable CS0618 // Type or member is obsolete
                         propertiesElastic.DBVersion = 2;
+#pragma warning restore CS0618 // Type or member is obsolete
 
                         elasticClient.Index(propertiesElastic, desc => desc.Id(hits[indexName].Id));
                         elasticClient.Flush(indexName);
 
+#pragma warning disable CS0618 // Type or member is obsolete
                         logger.LogInformation($"Updated to version {propertiesElastic.DBVersion} successfully");
+#pragma warning restore CS0618 // Type or member is obsolete
                     }
                 }
             }

--- a/src/Slamby.API/Services/DocumentService.cs
+++ b/src/Slamby.API/Services/DocumentService.cs
@@ -2,7 +2,7 @@
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
-using Microsoft.AspNet.Http;
+using Microsoft.AspNetCore.Http;
 using Newtonsoft.Json.Linq;
 using Slamby.API.Helpers;
 using Slamby.API.Models;

--- a/src/Slamby.API/Services/RedisManager.cs
+++ b/src/Slamby.API/Services/RedisManager.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using Microsoft.Extensions.OptionsModel;
 using MoreLinq;
 using Slamby.Common.Config;
 using Slamby.Common.DI;

--- a/src/Slamby.API/Services/TagService.cs
+++ b/src/Slamby.API/Services/TagService.cs
@@ -2,7 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
-using Microsoft.AspNet.Http;
+using Microsoft.AspNetCore.Http;
 using Slamby.API.Helpers;
 using Slamby.API.Models;
 using Slamby.API.Resources;

--- a/src/Slamby.API/Services/UrlProvider.cs
+++ b/src/Slamby.API/Services/UrlProvider.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.AspNet.Http;
+﻿using Microsoft.AspNetCore.Http;
 using Slamby.API.Helpers;
 using Slamby.Common.Config;
 using Slamby.Common.DI;

--- a/src/Slamby.API/Slamby.API.xproj
+++ b/src/Slamby.API/Slamby.API.xproj
@@ -4,12 +4,11 @@
     <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">14.0</VisualStudioVersion>
     <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
   </PropertyGroup>
-  <Import Project="$(VSToolsPath)\DNX\Microsoft.DNX.Props" Condition="'$(VSToolsPath)' != ''" />
+  <Import Project="$(VSToolsPath)\DotNet\Microsoft.DotNet.Props" Condition="'$(VSToolsPath)' != ''" />
   <PropertyGroup Label="Globals">
     <ProjectGuid>d6534685-64a4-4afe-993d-c7ad1b6d489e</ProjectGuid>
     <RootNamespace>Slamby.API</RootNamespace>
-    <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'=='' ">..\..\artifacts\obj</BaseIntermediateOutputPath>
-    <OutputPath Condition="'$(OutputPath)'=='' ">..\..\artifacts\bin\</OutputPath>
+    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
     <SccProjectName>SAK</SccProjectName>
     <SccProvider>SAK</SccProvider>
     <SccAuxPath>SAK</SccAuxPath>
@@ -20,5 +19,5 @@
   </PropertyGroup>
   <ItemGroup>
   </ItemGroup>
-  <Import Project="$(VSToolsPath)\DNX\Microsoft.DNX.targets" Condition="'$(VSToolsPath)' != ''" />
+  <Import Project="$(VSToolsPath)\DotNet.Web\Microsoft.DotNet.Web.targets" Condition="'$(VSToolsPath)' != ''" />
 </Project>

--- a/src/Slamby.API/Slamby.API.xproj
+++ b/src/Slamby.API/Slamby.API.xproj
@@ -8,8 +8,8 @@
   <PropertyGroup Label="Globals">
     <ProjectGuid>d6534685-64a4-4afe-993d-c7ad1b6d489e</ProjectGuid>
     <RootNamespace>Slamby.API</RootNamespace>
-    <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'=='' ">..\artifacts\obj\$(MSBuildProjectName)</BaseIntermediateOutputPath>
-    <OutputPath Condition="'$(OutputPath)'=='' ">.\bin\</OutputPath>
+    <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'=='' ">..\..\artifacts\obj</BaseIntermediateOutputPath>
+    <OutputPath Condition="'$(OutputPath)'=='' ">..\..\artifacts\bin\</OutputPath>
     <SccProjectName>SAK</SccProjectName>
     <SccProvider>SAK</SccProvider>
     <SccAuxPath>SAK</SccAuxPath>

--- a/src/Slamby.API/Slamby.API.xproj
+++ b/src/Slamby.API/Slamby.API.xproj
@@ -9,7 +9,7 @@
     <ProjectGuid>d6534685-64a4-4afe-993d-c7ad1b6d489e</ProjectGuid>
     <RootNamespace>Slamby.API</RootNamespace>
     <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'=='' ">..\artifacts\obj\$(MSBuildProjectName)</BaseIntermediateOutputPath>
-    <OutputPath Condition="'$(OutputPath)'=='' ">..\artifacts\bin\$(MSBuildProjectName)\</OutputPath>
+    <OutputPath Condition="'$(OutputPath)'=='' ">.\bin\</OutputPath>
     <SccProjectName>SAK</SccProjectName>
     <SccProvider>SAK</SccProvider>
     <SccAuxPath>SAK</SccAuxPath>

--- a/src/Slamby.API/Startup.cs
+++ b/src/Slamby.API/Startup.cs
@@ -1,35 +1,33 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Globalization;
-using System.IO;
-using System.Linq;
+﻿using System.Linq;
 using System.Reflection;
-using Microsoft.AspNet.Builder;
-using Microsoft.AspNet.FileProviders;
-using Microsoft.AspNet.Hosting;
-using Microsoft.AspNet.Http;
-using Microsoft.AspNet.Http.Features;
-using Microsoft.AspNet.StaticFiles;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
-using Microsoft.Extensions.OptionsModel;
-using Microsoft.Extensions.PlatformAbstractions;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Converters;
-using Serilog;
-using Serilog.Events;
 using Serilog.Sinks.RollingFile;
 using Slamby.API.Filters;
 using Slamby.API.Helpers;
 using Slamby.API.Helpers.Swashbuckle;
 using Slamby.API.Middlewares;
+using Microsoft.AspNetCore.Hosting;
+using System.Globalization;
+using System.Collections.Generic;
+using System;
 using Slamby.Common.Config;
-using Slamby.Common.DI;
+using System.IO;
 using Slamby.Common.Helpers;
+using Serilog.Events;
+using Serilog;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Options;
 using Slamby.Elastic.Factories;
 using StackExchange.Redis;
-using Swashbuckle.SwaggerGen.Generator;
+using Slamby.Common.DI;
+using Microsoft.AspNetCore.Builder;
+using Swashbuckle.Swagger.Model;
+using Microsoft.AspNetCore.StaticFiles;
+using Microsoft.Extensions.FileProviders;
 
 namespace Slamby.API
 {
@@ -51,7 +49,6 @@ namespace Slamby.API
 
         public IConfigurationRoot Configuration { get; set; }
 
-        public IHostingEnvironment HostingEnvironment { get; set; }
 
         public ILoggerFactory LoggerFactory { get; private set; }
 
@@ -59,26 +56,22 @@ namespace Slamby.API
 
         #endregion
 
-        public Startup(IHostingEnvironment env, ILoggerFactory loggerFactory, IApplicationEnvironment app)
+        public Startup(IHostingEnvironment env)
         {
             try
             {
                 CultureInfo.CurrentCulture = CultureInfo.InvariantCulture;
                 
-                HostingEnvironment = env;
-                LoggerFactory = loggerFactory;
-
                 // Set up configuration sources.
                 var builder = new ConfigurationBuilder()
                     .AddJsonFile("appsettings.json")
                     .AddJsonFile($"appsettings.{env.EnvironmentName}.json", optional: true)
-                    .AddJsonFile("project.json")
                     .AddEnvironmentVariables();
 
                 Configuration = builder.Build();
                 Configuration.GetSection("SlambyApi").Bind(SiteConfig);
 
-                StartupLogger(app, env);
+                StartupLogger(env);
             }
             catch (Exception ex)
             {
@@ -88,22 +81,22 @@ namespace Slamby.API
 
         #region Startup
 
-        private void StartupLogger(IApplicationEnvironment env, IHostingEnvironment hostingEnv)
+        private void StartupLogger(IHostingEnvironment env)
         {
             var minimumLevel = Configuration.GetEnumValue("SlambyApi:Serilog:MinimumLevel", LogEventLevel.Debug);
-            var retainedFileCountLimit = Configuration.Get("SlambyApi:Serilog:RetainedFileCountLimit", 7);
+            var retainedFileCountLimit = Configuration.GetValue("SlambyApi:Serilog:RetainedFileCountLimit", 7);
             var output = Configuration["SlambyApi:Serilog:Output"];
 
             var loggerConfiguration = new LoggerConfiguration()
                .MinimumLevel.Is(minimumLevel)
                .Enrich.FromLogContext();
-            if (hostingEnv.IsDevelopment()) loggerConfiguration.WriteTo.LiterateConsole(minimumLevel);
+            if (env.IsDevelopment()) loggerConfiguration.WriteTo.LiterateConsole(minimumLevel);
 
             if (!string.IsNullOrWhiteSpace(output))
             {
                 if (!Path.IsPathRooted(output))
                 {
-                    output = Path.GetFullPath(Path.Combine(env.ApplicationBasePath, output));
+                    output = Path.GetFullPath(Path.Combine(env.ContentRootPath, output));
                 }
 
                 loggerConfiguration.WriteTo.RollingFile(
@@ -123,10 +116,9 @@ namespace Slamby.API
         {
             try
             {
-                if (!string.IsNullOrEmpty(Configuration.Get("SlambyApi:Elm:Key", string.Empty)))
+                if (!string.IsNullOrEmpty(Configuration.GetValue("SlambyApi:Elm:Key", string.Empty)))
                 {
-                    services.AddElm();
-                    services.ConfigureElm(options =>
+                    services.AddElm(options =>
                     {
                         options.Path = new PathString("/elm");
                         options.Filter = (name, level) => level >= LogLevel.Information;
@@ -147,9 +139,9 @@ namespace Slamby.API
 
         private void ConfigureResourceDependentVars(IServiceCollection services)
         {
-            var maxIndexBulkSize = Configuration.Get("SlambyApi:Resources:MaxIndexBulkSize", 0);
-            var maxIndexBulkCount = Configuration.Get("SlambyApi:Resources:MaxIndexBulkCount", 0);
-            var maxSearchBulkCount = Configuration.Get("SlambyApi:Resources:MaxSearchBulkCount", 0);
+            var maxIndexBulkSize = Configuration.GetValue("SlambyApi:Resources:MaxIndexBulkSize", 0);
+            var maxIndexBulkCount = Configuration.GetValue("SlambyApi:Resources:MaxIndexBulkCount", 0);
+            var maxSearchBulkCount = Configuration.GetValue("SlambyApi:Resources:MaxSearchBulkCount", 0);
 
             if (maxIndexBulkSize == 0 || maxIndexBulkCount == 0 || maxSearchBulkCount == 0)
             {
@@ -203,8 +195,7 @@ namespace Slamby.API
             }
 
             // Add DependencyAttribute (ScopedDependency, SingletonDependency, TransientDependency) to the class in order to be scanned
-            services.AddDependencyScanning()
-                .Scan();
+            services.ConfigureAttributedDependencies();
 
             //services.Dump();
         }
@@ -222,11 +213,16 @@ namespace Slamby.API
                     TermsOfService = "None"
                 });
                 //options.OrderActionGroupsBy(new SwaggerGroupNameComparer());
+
                 options.GroupActionsBy(SwaggerHelper.GetActionGroup);
+
                 //options.SecurityDefinitions.Add(new KeyValuePair<string, SecurityScheme>("Slamby", new ApiKeyScheme() { Type = "apiKey", In = "header", Name = "api_secret", Description = "Http authentication. Ex: Authorization: Slamby <apisecret>" }));
                 //options.DocumentFilter(new SwaggerSchemaDocumentFilter(new List<string> { "http" }, "localhost:29689", "/"));
                 options.DescribeAllEnumsAsStrings();
-                options.ModelFilter<RegexModelFilter>();
+               
+                //TODO: check this
+                options.SchemaFilter<RegexSchemaFilter>();
+                options.OperationFilter<ApplySwaggerResponseFilterAttributesOperationFilter>();
 
                 var sdkXmlDocumentation = typeof(SDK.Net.ApiClient)
                     .GetTypeInfo()
@@ -245,8 +241,8 @@ namespace Slamby.API
             //{
             //    mvcBuilder.AddMvcOptions(o => o.Filters.Add(typeof(SdkVersionFilter)));
             //}
-            mvcBuilder.AddMvcOptions(o => o.Filters.Add(new ModelValidationFilter()));
-            mvcBuilder.AddMvcOptions(o => o.Filters.Add(new GlobalExceptionFilter(LoggerFactory, SiteConfig)));
+            mvcBuilder.AddMvcOptions(o => o.Filters.Add(typeof(ModelValidationFilter)));
+            mvcBuilder.AddMvcOptions(o => o.Filters.Add(typeof(GlobalExceptionFilter)));
 
             if (SiteConfig.Redis.Enabled)
             {
@@ -255,13 +251,17 @@ namespace Slamby.API
 
             mvcBuilder.AddJsonOptions(o => o.SerializerSettings.Converters.Add(new StringEnumConverter()));
 
-            services.ConfigureRouting(routeOptions =>
+            services.AddRouting(routeOptions =>
             {
                 routeOptions.AppendTrailingSlash = true;
                 routeOptions.LowercaseUrls = true;
             });
 
-            services.AddCaching();
+            services.AddDistributedRedisCache(options =>
+            {
+                options.Configuration = Configuration["Redis:Configuration"];
+            });
+
             services.AddSession(options =>
             {
                 options.IdleTimeout = TimeSpan.FromMinutes(30);
@@ -289,7 +289,7 @@ namespace Slamby.API
 
             app.UseRequestSizeLimit();
 
-            if (!string.IsNullOrEmpty(Configuration.Get("SlambyApi:Elm:Key", string.Empty))) {
+            if (!string.IsNullOrEmpty(Configuration.GetValue("SlambyApi:Elm:Key", string.Empty))) {
                 app.UseElmSecurity();
                 app.UseElmStyleUrlFix();
                 app.UseElmPage(); // Shows the logs at the specified path
@@ -313,15 +313,15 @@ namespace Slamby.API
             {
                 startupService.Startup();
 
-                app.UseIISPlatformHandler();
 
                 if (env.IsDevelopment())
                 {
-                    app.UseSwaggerGen();
+                    app.UseSwagger();
                     app.UseSwaggerUi("swagger/ui", "/swagger/latest/swagger.json");
                 }
 
                 app.UseGzip();
+
                 app.UseRequestLogger();
 
                 // Set up custom content types - associating file extension to MIME type
@@ -336,7 +336,6 @@ namespace Slamby.API
                 app.UseApiHeaderVersion();
                 app.UseApiHeaderAuthentication();
                 app.UseElapsedTime();
-
                 app.UseMvc();
 
                 app.UseNotFound();
@@ -352,8 +351,5 @@ namespace Slamby.API
                 app.WriteExceptionResponse(logger, ex, "Startup Runtime Error");
             }
         }
-
-        // Entry point for the application.
-        public static void Main(string[] args) => WebApplication.Run<Startup>(args);
     }
 }

--- a/src/Slamby.API/Startup.cs
+++ b/src/Slamby.API/Startup.cs
@@ -31,6 +31,7 @@ using Microsoft.Extensions.FileProviders;
 using System.Threading.Tasks;
 using System.Net;
 using System.Net.Sockets;
+using Newtonsoft.Json.Serialization;
 
 namespace Slamby.API
 {
@@ -269,7 +270,12 @@ namespace Slamby.API
                 mvcBuilder.AddMvcOptions(o => o.Filters.Add(typeof(ThrottleActionFilter)));
             }
 
-            mvcBuilder.AddJsonOptions(o => o.SerializerSettings.Converters.Add(new StringEnumConverter()));
+            mvcBuilder.AddJsonOptions(o =>
+            {
+                o.SerializerSettings.Converters.Add(new StringEnumConverter());
+                //HACK: see https://github.com/aspnet/Mvc/issues/4842
+                o.SerializerSettings.ContractResolver = new DefaultContractResolver();
+            });
 
             services.AddRouting(routeOptions =>
             {

--- a/src/Slamby.API/Startup.cs
+++ b/src/Slamby.API/Startup.cs
@@ -64,6 +64,7 @@ namespace Slamby.API
                 
                 // Set up configuration sources.
                 var builder = new ConfigurationBuilder()
+                    .SetBasePath(env.ContentRootPath)
                     .AddJsonFile("appsettings.json")
                     .AddJsonFile($"appsettings.{env.EnvironmentName}.json", optional: true)
                     .AddEnvironmentVariables();

--- a/src/Slamby.API/project.json
+++ b/src/Slamby.API/project.json
@@ -72,6 +72,21 @@
     "exclude": [
       "wwwroot",
       "node_modules"
+    ],
+    "include": [
+      "appsettings.json",
+      "docker-compose.yml",
+      "Dockerfile",
+      ".dockerignore"
     ]
+  },
+  "buildOptions": {
+    "debugType": "portable",
+    "emitEntryPoint": true,
+    "preserveCompilationContext": true,
+    "warningsAsErrors": true
+  },
+  "tooling": {
+    "defaultNamespace": "Slamby.API"
   }
 }

--- a/src/Slamby.API/project.json
+++ b/src/Slamby.API/project.json
@@ -37,7 +37,7 @@
     "Microsoft.Extensions.Logging.Debug": "1.0.0",
     "Microsoft.AspNetCore.Diagnostics.Elm": "0.2.0-preview1-final",
     "NEST": "2.4.6",
-    "protobuf-net": "2.1.0-alpha-1",
+    "protobuf-net": "2.1.0",
     "Serilog.Extensions.Logging": "1.2.0",
     "Serilog.Sinks.Literate": "2.0.0",
     "Serilog.Sinks.RollingFile": "2.0.0",

--- a/src/Slamby.API/project.json
+++ b/src/Slamby.API/project.json
@@ -1,14 +1,20 @@
 {
   "version": "1.1.0",
   "description": "Slamby.API ",
-  "authors": [ "Zsolt Illes", "Attila Laszlo" ],
+  "authors": [
+    "Zsolt Illes",
+    "Attila Laszlo"
+  ],
   "packOptions": {
     "repository": {
       "url": "https://github.com/slamby/slamby-api",
       "type": "git"
     },
     "licenseUrl": "https://raw.githubusercontent.com/slamby/slamby-api/master/LICENSE",
-    "owners": [ "Zsolt Illes", "Attila Laszlo" ]
+    "owners": [
+      "Zsolt Illes",
+      "Attila Laszlo"
+    ]
   },
   "dependencies": {
     "Elasticsearch.Net": "2.4.6",
@@ -16,7 +22,7 @@
     "Microsoft.AspNetCore.Diagnostics": "1.0.0",
     "Microsoft.AspNetCore.Mvc": "1.0.1",
     "Microsoft.AspNetCore.Cors": "1.0.0",
-    "Microsoft.Extensions.Caching.Redis.Core": "1.0.3",
+    "Microsoft.Extensions.Caching.Redis": "1.1.0-preview1-final",
     "Microsoft.Extensions.Caching.Memory": "1.0.0",
     "Microsoft.AspNetCore.Server.IISIntegration": "1.0.0",
     "Microsoft.AspNetCore.Server.Kestrel": "1.0.1",
@@ -32,17 +38,18 @@
     "Microsoft.AspNetCore.Diagnostics.Elm": "0.2.0-preview1-final",
     "NEST": "2.4.6",
     "protobuf-net": "2.1.0-alpha-1",
-    "Serilog.Extensions.Logging": "1.0.0-rc1-final-10092",
-    "Serilog.Sinks.Literate": "2.0.0-beta-21",
-    "Serilog.Sinks.RollingFile": "2.0.0-beta-700",
+    "Serilog.Extensions.Logging": "1.2.0",
+    "Serilog.Sinks.Literate": "2.0.0",
+    "Serilog.Sinks.RollingFile": "2.0.0",
     "Slamby.Cerebellum": "1.0.0-*",
     "Slamby.Common": "1.0.0-*",
     "Slamby.Elastic": "1.0.0-*",
-    "StackExchange.Redis.StrongName.Core": "1.1.605",
+    "StackExchange.Redis.StrongName": "1.1.605",
     "Swashbuckle.SwaggerGen": "6.0.0-beta902",
     "Swashbuckle.SwaggerUi": "6.0.0-beta902",
     "Microsoft.Extensions.Configuration.Binder": "1.1.0-preview1-final",
     "Microsoft.AspNetCore.Session": "1.0.0"
+
   },
   "tools": {
     "Microsoft.AspNetCore.Razor.Tools": "1.0.0-preview2-final",
@@ -62,7 +69,7 @@
       ],
       "dependencies": {
         "Microsoft.NETCore.App": {
-          "version": "1.0.1",
+          "version": "1.1.0-preview1-001100-00",
           "type": "platform"
         }
       }

--- a/src/Slamby.API/project.json
+++ b/src/Slamby.API/project.json
@@ -2,30 +2,35 @@
   "version": "1.1.0",
   "description": "Slamby.API ",
   "authors": [ "Zsolt Illes", "Attila Laszlo" ],
-  "projectUrl": "https://github.com/slamby/slamby-api",
-  "licenseUrl": "https://raw.githubusercontent.com/slamby/slamby-api/master/LICENSE",
-  "compilationOptions": {
-    "emitEntryPoint": true
+  "packOptions": {
+    "repository": {
+      "url": "https://github.com/slamby/slamby-api",
+      "type": "git"
+    },
+    "licenseUrl": "https://raw.githubusercontent.com/slamby/slamby-api/master/LICENSE",
+    "owners": [ "Zsolt Illes", "Attila Laszlo" ]
   },
-
   "dependencies": {
-    "Elasticsearch.Net": "2.1.1",
-    "FastMember": "1.1.0-beta1",
-    "Microsoft.AspNet.Cors": "6.0.0-rc1-final",
-    "Microsoft.AspNet.Diagnostics": "1.0.0-rc1-final",
-    "Microsoft.AspNet.Diagnostics.Elm": "1.0.0-rc1-final",
-    "Microsoft.AspNet.IISPlatformHandler": "1.0.0-rc1-final",
-    "Microsoft.AspNet.Mvc": "6.0.0-rc1-final",
-    "Microsoft.AspNet.Mvc.WebApiCompatShim": "6.0.0-rc1-final",
-    "Microsoft.AspNet.Server.Kestrel": "1.0.0-rc1-final",
-    "Microsoft.AspNet.Session": "1.0.0-rc1-final",
-    "Microsoft.AspNet.StaticFiles": "1.0.0-rc1-final",
-    "Microsoft.Extensions.Configuration.FileProviderExtensions": "1.0.0-rc1-final",
-    "Microsoft.Extensions.Configuration.Json": "1.0.0-rc1-final",
-    "Microsoft.Extensions.Logging": "1.0.0-rc1-final",
-    "Microsoft.Extensions.Logging.Console": "1.0.0-rc1-final",
-    "Microsoft.Extensions.Logging.Debug": "1.0.0-rc1-final",
-    "NEST": "2.1.1",
+    "Elasticsearch.Net": "2.4.6",
+    "FastMember": "1.1.0",
+    "Microsoft.AspNetCore.Diagnostics": "1.0.0",
+    "Microsoft.AspNetCore.Mvc": "1.0.1",
+    "Microsoft.AspNetCore.Cors": "1.0.0",
+    "Microsoft.Extensions.Caching.Redis.Core": "1.0.3",
+    "Microsoft.Extensions.Caching.Memory": "1.0.0",
+    "Microsoft.AspNetCore.Server.IISIntegration": "1.0.0",
+    "Microsoft.AspNetCore.Server.Kestrel": "1.0.1",
+    "Microsoft.AspNetCore.Authentication.Cookies": "1.0.0",
+    "Microsoft.AspNetCore.StaticFiles": "1.0.0",
+    "Microsoft.Extensions.Configuration.EnvironmentVariables": "1.0.0",
+    "Microsoft.Extensions.Configuration.Json": "1.0.0",
+    "Microsoft.Extensions.Configuration.CommandLine": "1.0.0",
+    "Microsoft.Extensions.Options.ConfigurationExtensions": "1.1.0-preview1-final",
+    "Microsoft.Extensions.Logging": "1.0.0",
+    "Microsoft.Extensions.Logging.Console": "1.0.0",
+    "Microsoft.Extensions.Logging.Debug": "1.0.0",
+    "Microsoft.AspNetCore.Diagnostics.Elm": "0.2.0-preview1-final",
+    "NEST": "2.4.6",
     "protobuf-net": "2.1.0-alpha-1",
     "Serilog.Extensions.Logging": "1.0.0-rc1-final-10092",
     "Serilog.Sinks.Literate": "2.0.0-beta-21",
@@ -33,36 +38,40 @@
     "Slamby.Cerebellum": "1.0.0-*",
     "Slamby.Common": "1.0.0-*",
     "Slamby.Elastic": "1.0.0-*",
-    "StackExchange.Redis": "1.1.572-alpha",
-    "Swashbuckle.SwaggerGen": "6.0.0-rc1-slamby",
-    "Swashbuckle.SwaggerUi": "6.0.0-rc1-slamby",
-    "System.IO": "4.0.11-beta-23516",
-    "System.IO.Compression.ZipFile": "4.0.1-beta-23516",
-    "System.Linq": "4.0.1-beta-23516",
-    "System.Linq.Parallel": "4.0.1-beta-23516",
-    "System.Linq.Queryable": "4.0.1-beta-23516",
-    "System.Reflection.Extensions": "4.0.1-beta-23516",
-    "System.Net.Security": "4.0.0-beta-23225",
-    "System.Collections.Immutable": "1.1.37"
+    "StackExchange.Redis.StrongName.Core": "1.1.605",
+    "Swashbuckle.SwaggerGen": "6.0.0-beta902",
+    "Swashbuckle.SwaggerUi": "6.0.0-beta902",
+    "Microsoft.Extensions.Configuration.Binder": "1.1.0-preview1-final",
+    "Microsoft.AspNetCore.Session": "1.0.0"
   },
-
-
-  "commands": {
-    "web": "Microsoft.AspNet.Server.Kestrel",
-    "prod-server": "Microsoft.AspNet.Server.Kestrel --server.urls http://*:80"
+  "tools": {
+    "Microsoft.AspNetCore.Razor.Tools": "1.0.0-preview2-final",
+    "Microsoft.AspNetCore.Server.IISIntegration.Tools": "1.0.0-preview2-final",
+    "Microsoft.DotNet.Watcher.Tools": "1.0.0-preview2-final"
   },
-
-  "frameworks": {
-    "dnxcore50": {
+  "runtimeOptions": {
+    "configProperties": {
+      "System.GC.Server": true
     }
   },
-
-  "exclude": [
-    "wwwroot",
-    "node_modules"
-  ],
-  "publishExclude": [
-    "**.user",
-    "**.vspscc"
-  ]
+  "frameworks": {
+    "netcoreapp1.0": {
+      "imports": [
+        "dotnet5.6",
+        "portable-net45+win8"
+      ],
+      "dependencies": {
+        "Microsoft.NETCore.App": {
+          "version": "1.0.1",
+          "type": "platform"
+        }
+      }
+    }
+  },
+  "publishOptions": {
+    "exclude": [
+      "wwwroot",
+      "node_modules"
+    ]
+  }
 }

--- a/src/Slamby.API/project.json
+++ b/src/Slamby.API/project.json
@@ -62,7 +62,7 @@
     }
   },
   "frameworks": {
-    "netcoreapp1.0": {
+    "netcoreapp1.1": {
       "imports": [
         "dotnet5.6",
         "portable-net45+win8"

--- a/src/Slamby.API/web.config
+++ b/src/Slamby.API/web.config
@@ -1,0 +1,9 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <system.webServer>
+    <handlers>
+      <add name="aspNetCore" path="*" verb="*" modules="AspNetCoreModule" resourceType="Unspecified" />
+    </handlers>
+    <aspNetCore processPath="%LAUNCHER_PATH%" arguments="%LAUNCHER_ARGS%" forwardWindowsAuthToken="false" stdoutLogEnabled="false" />
+  </system.webServer>
+</configuration>

--- a/src/Slamby.Cerebellum/Slamby.Cerebellum.xproj
+++ b/src/Slamby.Cerebellum/Slamby.Cerebellum.xproj
@@ -9,7 +9,7 @@
     <ProjectGuid>f152ff04-f967-45fa-9816-f2669b87bd47</ProjectGuid>
     <RootNamespace>Slamby.Cerebellum</RootNamespace>
     <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'=='' ">..\artifacts\obj\$(MSBuildProjectName)</BaseIntermediateOutputPath>
-    <OutputPath Condition="'$(OutputPath)'=='' ">..\artifacts\bin\$(MSBuildProjectName)\</OutputPath>
+    <OutputPath Condition="'$(OutputPath)'=='' ">.\bin\</OutputPath>
     <SccProjectName>SAK</SccProjectName>
     <SccProvider>SAK</SccProvider>
     <SccAuxPath>SAK</SccAuxPath>

--- a/src/Slamby.Cerebellum/Slamby.Cerebellum.xproj
+++ b/src/Slamby.Cerebellum/Slamby.Cerebellum.xproj
@@ -8,8 +8,8 @@
   <PropertyGroup Label="Globals">
     <ProjectGuid>f152ff04-f967-45fa-9816-f2669b87bd47</ProjectGuid>
     <RootNamespace>Slamby.Cerebellum</RootNamespace>
-    <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'=='' ">..\artifacts\obj\$(MSBuildProjectName)</BaseIntermediateOutputPath>
-    <OutputPath Condition="'$(OutputPath)'=='' ">.\bin\</OutputPath>
+    <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'=='' ">..\..\artifacts\obj</BaseIntermediateOutputPath>
+    <OutputPath Condition="'$(OutputPath)'=='' ">..\..\artifacts\bin\</OutputPath>
     <SccProjectName>SAK</SccProjectName>
     <SccProvider>SAK</SccProvider>
     <SccAuxPath>SAK</SccAuxPath>

--- a/src/Slamby.Cerebellum/Slamby.Cerebellum.xproj
+++ b/src/Slamby.Cerebellum/Slamby.Cerebellum.xproj
@@ -4,12 +4,11 @@
     <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">14.0</VisualStudioVersion>
     <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
   </PropertyGroup>
-  <Import Project="$(VSToolsPath)\DNX\Microsoft.DNX.Props" Condition="'$(VSToolsPath)' != ''" />
+  <Import Project="$(VSToolsPath)\DotNet\Microsoft.DotNet.Props" Condition="'$(VSToolsPath)' != ''" />
   <PropertyGroup Label="Globals">
     <ProjectGuid>f152ff04-f967-45fa-9816-f2669b87bd47</ProjectGuid>
     <RootNamespace>Slamby.Cerebellum</RootNamespace>
-    <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'=='' ">..\..\artifacts\obj</BaseIntermediateOutputPath>
-    <OutputPath Condition="'$(OutputPath)'=='' ">..\..\artifacts\bin\</OutputPath>
+	<TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
     <SccProjectName>SAK</SccProjectName>
     <SccProvider>SAK</SccProvider>
     <SccAuxPath>SAK</SccAuxPath>
@@ -18,5 +17,5 @@
   <PropertyGroup>
     <SchemaVersion>2.0</SchemaVersion>
   </PropertyGroup>
-  <Import Project="$(VSToolsPath)\DNX\Microsoft.DNX.targets" Condition="'$(VSToolsPath)' != ''" />
+  <Import Project="$(VSToolsPath)\DotNet\Microsoft.DotNet.targets" Condition="'$(VSToolsPath)' != ''" />
 </Project>

--- a/src/Slamby.Cerebellum/project.json
+++ b/src/Slamby.Cerebellum/project.json
@@ -2,20 +2,33 @@
   "version": "1.0.0-*",
   "description": "Slamby.Cerebellum Class Library",
   "authors": [ "Zsolt Illes", "Attila Laszlo", "Zsolt Rabai", "Agnes Nagy", "Bela Soos", "Peter Mezei" ],
-  "projectUrl": "https://github.com/slamby/slamby-api",
-  "licenseUrl": "https://raw.githubusercontent.com/slamby/slamby-api/master/LICENSE",
-
-  "frameworks": {
-    "dnxcore50": { }
+  "packOptions": {
+    "repository": {
+      "url": "https://github.com/slamby/slamby-api",
+      "type": "git"
+    },
+    "licenseUrl": "https://raw.githubusercontent.com/slamby/slamby-api/master/LICENSE",
+    "owners": [ "Zsolt Illes", "Attila Laszlo" ]
   },
-
+  "buildOptions": {
+    "warningsAsErrors": true
+  },
   "dependencies": {
-    "Microsoft.CSharp": "4.0.1-beta-23516",
-    "System.Collections": "4.0.11-beta-23516",
-    "System.Linq": "4.0.1-beta-23516",
-    "System.Runtime": "4.0.21-beta-23516",
-    "System.Threading": "4.0.11-beta-23516",
     "Slamby.Elastic": "1.0.0-*",
     "Slamby.Common": "1.0.0-*"
+  },
+  "frameworks": {
+    "netcoreapp1.0": {
+      "imports": [
+        "dotnet5.6",
+        "portable-net45+win8"
+      ],
+      "dependencies": {
+        "Microsoft.NETCore.App": {
+          "version": "1.0.1",
+          "type": "platform"
+        }
+      }
+    }
   }
 }

--- a/src/Slamby.Cerebellum/project.json
+++ b/src/Slamby.Cerebellum/project.json
@@ -25,7 +25,7 @@
       ],
       "dependencies": {
         "Microsoft.NETCore.App": {
-          "version": "1.0.1",
+          "version": "1.1.0-preview1-001100-00",
           "type": "platform"
         }
       }

--- a/src/Slamby.Cerebellum/project.json
+++ b/src/Slamby.Cerebellum/project.json
@@ -18,16 +18,12 @@
     "Slamby.Common": "1.0.0-*"
   },
   "frameworks": {
-    "netcoreapp1.0": {
+   "netstandard1.6": {
       "imports": [
-        "dotnet5.6",
         "portable-net45+win8"
       ],
       "dependencies": {
-        "Microsoft.NETCore.App": {
-          "version": "1.1.0-preview1-001100-00",
-          "type": "platform"
-        }
+        "NETStandard.Library": "1.6.0"
       }
     }
   }

--- a/src/Slamby.Common/DI/IServiceCollectionExtensions.cs
+++ b/src/Slamby.Common/DI/IServiceCollectionExtensions.cs
@@ -6,21 +6,11 @@ namespace Slamby.Common.DI
 {
     public static class IServiceCollectionExtensions
     {
-        public static IServiceCollection AddDependencyScanning(this IServiceCollection services)
-        {
-            services.AddSingleton<Scanner>();
-            return services;
-        }
-
-        public static IServiceCollection Scan(this IServiceCollection services)
+        public static IServiceCollection ConfigureAttributedDependencies(this IServiceCollection services)
         {
             var serviceProvider = services.BuildServiceProvider();
-            var appEnv = serviceProvider.GetService<IApplicationEnvironment>();
-            var scanner = serviceProvider.GetService<Scanner>();
-
-            scanner.RegisterAssembly(services, new AssemblyName(appEnv.ApplicationName));
-            scanner.RegisterAllAssemblies(services);
-
+            var applicationEnvironment = serviceProvider.GetService<ApplicationEnvironment>();
+            Scanner.RegisterAttributedDependencies(services, applicationEnvironment.ApplicationName);
             return services;
         }
     }

--- a/src/Slamby.Common/DI/IServiceCollectionExtensions.cs
+++ b/src/Slamby.Common/DI/IServiceCollectionExtensions.cs
@@ -1,6 +1,7 @@
 ﻿using System.Reflection;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.PlatformAbstractions;
+using Microsoft.AspNetCore.Hosting;
 
 namespace Slamby.Common.DI
 {
@@ -9,8 +10,8 @@ namespace Slamby.Common.DI
         public static IServiceCollection ConfigureAttributedDependencies(this IServiceCollection services)
         {
             var serviceProvider = services.BuildServiceProvider();
-            var applicationEnvironment = serviceProvider.GetService<ApplicationEnvironment>();
-            Scanner.RegisterAttributedDependencies(services, applicationEnvironment.ApplicationName);
+            var env = serviceProvider.GetService<IHostingEnvironment>();
+            Scanner.RegisterAttributedDependencies(services, env.ApplicationName);
             return services;
         }
     }

--- a/src/Slamby.Common/DI/Scanner.cs
+++ b/src/Slamby.Common/DI/Scanner.cs
@@ -26,7 +26,6 @@ namespace Slamby.Common.DI
                 {
                     var typeInfo = type.GetTypeInfo();
                     var dependencyAttributes = typeInfo.GetCustomAttributes<DependencyAttribute>();
-                    // Each dependency can be registered as various types
                     foreach (var dependencyAttribute in dependencyAttributes)
                     {
                         var serviceDescriptor = dependencyAttribute.BuildServiceDescriptor(typeInfo);
@@ -66,9 +65,7 @@ namespace Slamby.Common.DI
         }
 
         // Returns a list of libraries that references the assemblies in <see cref="ReferenceAssemblies"/>.
-        // By default it returns all assemblies that reference any of the primary MVC assemblies
-        // while ignoring MVC assemblies.
-        // Internal for unit testing
+        // By default it returns all assemblies that reference any of the primary Slamby assemblies
         private static IEnumerable<RuntimeLibrary> GetCandidateLibraries(DependencyContext dependencyContext)
         {
             if (ReferenceAssemblies == null)
@@ -95,7 +92,8 @@ namespace Slamby.Common.DI
                 var classification = DependencyClassification.Unknown;
                 if (referenceAssemblies.Contains(library.Name))
                 {
-                    classification = DependencyClassification.MvcReference;
+                    //all Slamby assembly can be a candidate
+                    classification = DependencyClassification.Candidate;
                 }
 
                 return new Dependency(library, classification);
@@ -106,7 +104,7 @@ namespace Slamby.Common.DI
                 Debug.Assert(_dependencies.ContainsKey(dependency));
 
                 var candidateEntry = _dependencies[dependency];
-                if (candidateEntry.Classification != DependencyClassification.Unknown)
+                if (candidateEntry.Classification != DependencyClassification.Unknown) //if the entry is already classified
                 {
                     return candidateEntry.Classification;
                 }
@@ -116,8 +114,7 @@ namespace Slamby.Common.DI
                     foreach (var candidateDependency in candidateEntry.Library.Dependencies)
                     {
                         var dependencyClassification = ComputeClassification(candidateDependency.Name);
-                        if (dependencyClassification == DependencyClassification.Candidate ||
-                            dependencyClassification == DependencyClassification.MvcReference)
+                        if (dependencyClassification == DependencyClassification.Candidate)//if it references a candidate library than it can be also a candidate
                         {
                             classification = DependencyClassification.Candidate;
                             break;
@@ -163,8 +160,7 @@ namespace Slamby.Common.DI
             {
                 Unknown = 0,
                 Candidate = 1,
-                NotCandidate = 2,
-                MvcReference = 3
+                NotCandidate = 2
             }
         }
     }

--- a/src/Slamby.Common/DI/Scanner.cs
+++ b/src/Slamby.Common/DI/Scanner.cs
@@ -1,62 +1,171 @@
-﻿using System.Collections.Generic;
+﻿using Microsoft.AspNetCore.Mvc.ApplicationParts;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyModel;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using System.Reflection;
-using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.PlatformAbstractions;
 
 namespace Slamby.Common.DI
 {
-    // http://dotnetliberty.com/index.php/2016/01/11/dependency-scanning-in-asp-net-5/
-    // http://dotnetliberty.com/index.php/2016/01/19/dependency-scanning-in-asp-net-5-part-2/
-    public class Scanner
+    /// <summary>
+    /// Discovers assemblies that are part of the application using the DependencyContext.
+    /// </summary>
+    /// <remarks>
+    /// Source: https://github.com/aspnet/Mvc/blob/760c8f38678118734399c58c2dac981ea6e47046/src/Microsoft.AspNetCore.Mvc.Core/Internal/DefaultAssemblyPartDiscoveryProvider.cs
+    /// </remarks>
+    internal static class Scanner
     {
-        private readonly ILibraryManager _libraryManager;
-        private readonly AssemblyName _thisAssemblyName;
-        private readonly List<string> _scannedAssembly = new List<string>();
 
-        public Scanner(ILibraryManager libraryManager)
+        internal static void RegisterAttributedDependencies(IServiceCollection services, string applicationName)
         {
-            _libraryManager = libraryManager;
-            _thisAssemblyName = new AssemblyName(GetType().GetTypeInfo().Assembly.FullName);
-        }
-
-        public void RegisterAllAssemblies(IServiceCollection services)
-        {
-            foreach (var assembly in GetAssembliesReferencingThis())
+            foreach (var assembly in DiscoverAssemblyParts(applicationName))
             {
-                RegisterAssembly(services, assembly);
-            }
-        }
-
-        public void RegisterAssembly(IServiceCollection services, AssemblyName assemblyName)
-        {
-            if (_scannedAssembly.Contains(assemblyName.FullName))
-            {
-                return;
-            }
-
-            var assembly = Assembly.Load(assemblyName);
-            foreach (var type in assembly.DefinedTypes)
-            {
-                var dependencyAttributes = type.GetCustomAttributes<DependencyAttribute>();
-                // Each dependency can be registered as various types
-                foreach (var dependencyAttribute in dependencyAttributes)
+                foreach (var type in assembly.GetTypes())
                 {
-                    var serviceDescriptor = dependencyAttribute.BuildServiceDescriptor(type);
-                    services.Add(serviceDescriptor);
+                    var typeInfo = type.GetTypeInfo();
+                    var dependencyAttributes = typeInfo.GetCustomAttributes<DependencyAttribute>();
+                    // Each dependency can be registered as various types
+                    foreach (var dependencyAttribute in dependencyAttributes)
+                    {
+                        var serviceDescriptor = dependencyAttribute.BuildServiceDescriptor(typeInfo);
+                        services.Add(serviceDescriptor);
+                    }
+                }
+            }
+        }
+
+        private static HashSet<string> ReferenceAssemblies { get; } = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+        {
+            "Slamby.Common",
+            "Slamby.API",
+            "Slamby.Cerebellum",
+            "Slamby.Elastic"
+        };
+
+        private static IEnumerable<Assembly> DiscoverAssemblyParts(string entryPointAssemblyName)
+        {
+            var entryAssembly = Assembly.Load(new AssemblyName(entryPointAssemblyName));
+            var context = DependencyContext.Load(Assembly.Load(new AssemblyName(entryPointAssemblyName)));
+
+            return GetCandidateAssemblies(entryAssembly, context);
+        }
+
+        private static IEnumerable<Assembly> GetCandidateAssemblies(Assembly entryAssembly, DependencyContext dependencyContext)
+        {
+            if (dependencyContext == null)
+            {
+                // Use the entry assembly as the sole candidate.
+                return new[] { entryAssembly };
+            }
+
+            return GetCandidateLibraries(dependencyContext)
+                .SelectMany(library => library.GetDefaultAssemblyNames(dependencyContext))
+                .Select(Assembly.Load);
+        }
+
+        // Returns a list of libraries that references the assemblies in <see cref="ReferenceAssemblies"/>.
+        // By default it returns all assemblies that reference any of the primary MVC assemblies
+        // while ignoring MVC assemblies.
+        // Internal for unit testing
+        private static IEnumerable<RuntimeLibrary> GetCandidateLibraries(DependencyContext dependencyContext)
+        {
+            if (ReferenceAssemblies == null)
+            {
+                return Enumerable.Empty<RuntimeLibrary>();
+            }
+
+            var candidatesResolver = new CandidateResolver(dependencyContext.RuntimeLibraries, ReferenceAssemblies);
+            return candidatesResolver.GetCandidates();
+        }
+
+        private sealed class CandidateResolver
+        {
+            private readonly IDictionary<string, Dependency> _dependencies;
+
+            public CandidateResolver(IReadOnlyList<RuntimeLibrary> dependencies, ISet<string> referenceAssemblies)
+            {
+                _dependencies = dependencies
+                    .ToDictionary(d => d.Name, d => CreateDependency(d, referenceAssemblies), StringComparer.OrdinalIgnoreCase);
+            }
+
+            private Dependency CreateDependency(RuntimeLibrary library, ISet<string> referenceAssemblies)
+            {
+                var classification = DependencyClassification.Unknown;
+                if (referenceAssemblies.Contains(library.Name))
+                {
+                    classification = DependencyClassification.MvcReference;
+                }
+
+                return new Dependency(library, classification);
+            }
+
+            private DependencyClassification ComputeClassification(string dependency)
+            {
+                Debug.Assert(_dependencies.ContainsKey(dependency));
+
+                var candidateEntry = _dependencies[dependency];
+                if (candidateEntry.Classification != DependencyClassification.Unknown)
+                {
+                    return candidateEntry.Classification;
+                }
+                else
+                {
+                    var classification = DependencyClassification.NotCandidate;
+                    foreach (var candidateDependency in candidateEntry.Library.Dependencies)
+                    {
+                        var dependencyClassification = ComputeClassification(candidateDependency.Name);
+                        if (dependencyClassification == DependencyClassification.Candidate ||
+                            dependencyClassification == DependencyClassification.MvcReference)
+                        {
+                            classification = DependencyClassification.Candidate;
+                            break;
+                        }
+                    }
+
+                    candidateEntry.Classification = classification;
+
+                    return classification;
                 }
             }
 
-            _scannedAssembly.Add(assemblyName.FullName);
-        }
+            public IEnumerable<RuntimeLibrary> GetCandidates()
+            {
+                foreach (var dependency in _dependencies)
+                {
+                    if (ComputeClassification(dependency.Key) == DependencyClassification.Candidate)
+                    {
+                        yield return dependency.Value.Library;
+                    }
+                }
+            }
 
-        private IEnumerable<AssemblyName> GetAssembliesReferencingThis()
-        {
-            var assemblies = _libraryManager.GetReferencingLibraries(_thisAssemblyName.Name)
-                .SelectMany(library => library.Assemblies)
-                .Concat(new[] { _thisAssemblyName }); // And add self since 'Slamby.Common' is not just for DI stuff, it can contains dependencies also
+            private class Dependency
+            {
+                public Dependency(RuntimeLibrary library, DependencyClassification classification)
+                {
+                    Library = library;
+                    Classification = classification;
+                }
 
-            return assemblies;
+                public RuntimeLibrary Library { get; }
+
+                public DependencyClassification Classification { get; set; }
+
+                public override string ToString()
+                {
+                    return $"Library: {Library.Name}, Classification: {Classification}";
+                }
+            }
+
+            private enum DependencyClassification
+            {
+                Unknown = 0,
+                Candidate = 1,
+                NotCandidate = 2,
+                MvcReference = 3
+            }
         }
     }
 }

--- a/src/Slamby.Common/Helpers/ConfigurationExtensions.cs
+++ b/src/Slamby.Common/Helpers/ConfigurationExtensions.cs
@@ -8,7 +8,7 @@ namespace Slamby.Common.Helpers
         public static T GetEnumValue<T>(this IConfigurationRoot configuration, string key, T defaultValue) where T: struct
         {
             T result;
-            return Enum.TryParse(configuration.Get<string>(key), out result) ? result : defaultValue;
+            return Enum.TryParse(configuration[key], out result) ? result : defaultValue;
         }
     }
 }

--- a/src/Slamby.Common/Helpers/HttpContextHelper.cs
+++ b/src/Slamby.Common/Helpers/HttpContextHelper.cs
@@ -1,6 +1,6 @@
-﻿using System;
+﻿using Microsoft.AspNetCore.Http;
+using System;
 using System.Linq;
-using Microsoft.AspNet.Http;
 
 namespace Slamby.Common.Helpers
 {

--- a/src/Slamby.Common/Helpers/HttpStatusCodeWithObjectResult.cs
+++ b/src/Slamby.Common/Helpers/HttpStatusCodeWithObjectResult.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.AspNet.Mvc;
+﻿using Microsoft.AspNetCore.Mvc;
 
 namespace Slamby.Common.Helpers
 {

--- a/src/Slamby.Common/Mapper/DynamicMapper.cs
+++ b/src/Slamby.Common/Mapper/DynamicMapper.cs
@@ -44,7 +44,7 @@ namespace Slamby.Common.Mapper
             {
                 mapper.PrepareMappings(sourceType);
             }
-            catch (ArgumentException ex)
+            catch (ArgumentException)
             {
                 return null;
             }

--- a/src/Slamby.Common/Services/DataSetSchemaValidatorService.cs
+++ b/src/Slamby.Common/Services/DataSetSchemaValidatorService.cs
@@ -1,10 +1,10 @@
 ﻿using System.Collections.Generic;
 using System.IO;
-using Microsoft.AspNet.Hosting;
 using Microsoft.Extensions.Logging;
 using NJsonSchema;
 using NJsonSchema.Validation;
 using Slamby.Common.DI;
+using Microsoft.AspNetCore.Hosting;
 
 namespace Slamby.Common.Services
 {

--- a/src/Slamby.Common/Services/HttpHeaderDataSetSelector.cs
+++ b/src/Slamby.Common/Services/HttpHeaderDataSetSelector.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.AspNet.Http;
+﻿using Microsoft.AspNetCore.Http;
 using Slamby.Common.DI;
 using Slamby.Common.Services.Interfaces;
 using static Slamby.SDK.Net.Constants;

--- a/src/Slamby.Common/Services/MachineResourceService.cs
+++ b/src/Slamby.Common/Services/MachineResourceService.cs
@@ -4,12 +4,12 @@ using System.IO;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.AspNet.Hosting;
-using Microsoft.Extensions.Logging;
-using Microsoft.Extensions.PlatformAbstractions;
 using Slamby.Common.Config;
 using Slamby.Common.DI;
 using Slamby.SDK.Net.Models;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.PlatformAbstractions;
 
 namespace Slamby.Common.Services
 {
@@ -28,7 +28,7 @@ namespace Slamby.Common.Services
         
         readonly SiteConfig siteConfig;
 
-        public MachineResourceService(ILogger<MachineResourceService> logger, SiteConfig siteConfig, IApplicationEnvironment env,
+        public MachineResourceService(ILogger<MachineResourceService> logger, SiteConfig siteConfig, ApplicationEnvironment env,
             IApplicationLifetime applicationLifetime)
         {
             this.siteConfig = siteConfig;

--- a/src/Slamby.Common/Services/MachineResourceService.cs
+++ b/src/Slamby.Common/Services/MachineResourceService.cs
@@ -28,7 +28,7 @@ namespace Slamby.Common.Services
         
         readonly SiteConfig siteConfig;
 
-        public MachineResourceService(ILogger<MachineResourceService> logger, SiteConfig siteConfig, ApplicationEnvironment env,
+        public MachineResourceService(ILogger<MachineResourceService> logger, SiteConfig siteConfig, IHostingEnvironment env,
             IApplicationLifetime applicationLifetime)
         {
             this.siteConfig = siteConfig;
@@ -37,7 +37,7 @@ namespace Slamby.Common.Services
             path = siteConfig.Resources.LogPath;
             if (!Path.IsPathRooted(path))
             {
-                path = Path.GetFullPath(Path.Combine(env.ApplicationBasePath, path));
+                path = Path.GetFullPath(Path.Combine(env.ContentRootPath, path));
             }
 
             logger.LogInformation($"{nameof(MachineResourceService)} using resource path: {path}");

--- a/src/Slamby.Common/Services/ParallelService.cs
+++ b/src/Slamby.Common/Services/ParallelService.cs
@@ -1,9 +1,9 @@
 ﻿using System;
 using System.Linq;
 using System.Threading.Tasks;
-using Microsoft.AspNet.Http;
 using Slamby.Common.Config;
 using Slamby.Common.DI;
+using Microsoft.AspNetCore.Http;
 
 namespace Slamby.Common.Services
 {

--- a/src/Slamby.Common/Slamby.Common.xproj
+++ b/src/Slamby.Common/Slamby.Common.xproj
@@ -4,12 +4,11 @@
     <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">14.0</VisualStudioVersion>
     <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
   </PropertyGroup>
-  <Import Project="$(VSToolsPath)\DNX\Microsoft.DNX.Props" Condition="'$(VSToolsPath)' != ''" />
+  <Import Project="$(VSToolsPath)\DotNet\Microsoft.DotNet.Props" Condition="'$(VSToolsPath)' != ''" />
   <PropertyGroup Label="Globals">
     <ProjectGuid>c911131d-1159-4a39-8555-7e4bc594976b</ProjectGuid>
     <RootNamespace>Slamby.Common</RootNamespace>
-    <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'=='' ">..\..\artifacts\obj</BaseIntermediateOutputPath>
-    <OutputPath Condition="'$(OutputPath)'=='' ">..\..\artifacts\bin\</OutputPath>
+    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
     <SccProjectName>SAK</SccProjectName>
     <SccProvider>SAK</SccProvider>
     <SccAuxPath>SAK</SccAuxPath>
@@ -18,5 +17,5 @@
   <PropertyGroup>
     <SchemaVersion>2.0</SchemaVersion>
   </PropertyGroup>
-  <Import Project="$(VSToolsPath)\DNX\Microsoft.DNX.targets" Condition="'$(VSToolsPath)' != ''" />
+  <Import Project="$(VSToolsPath)\DotNet\Microsoft.DotNet.targets" Condition="'$(VSToolsPath)' != ''" />
 </Project>

--- a/src/Slamby.Common/Slamby.Common.xproj
+++ b/src/Slamby.Common/Slamby.Common.xproj
@@ -9,7 +9,7 @@
     <ProjectGuid>c911131d-1159-4a39-8555-7e4bc594976b</ProjectGuid>
     <RootNamespace>Slamby.Common</RootNamespace>
     <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'=='' ">..\artifacts\obj\$(MSBuildProjectName)</BaseIntermediateOutputPath>
-    <OutputPath Condition="'$(OutputPath)'=='' ">..\artifacts\bin\$(MSBuildProjectName)\</OutputPath>
+    <OutputPath Condition="'$(OutputPath)'=='' ">.\bin\</OutputPath>
     <SccProjectName>SAK</SccProjectName>
     <SccProvider>SAK</SccProvider>
     <SccAuxPath>SAK</SccAuxPath>

--- a/src/Slamby.Common/Slamby.Common.xproj
+++ b/src/Slamby.Common/Slamby.Common.xproj
@@ -8,8 +8,8 @@
   <PropertyGroup Label="Globals">
     <ProjectGuid>c911131d-1159-4a39-8555-7e4bc594976b</ProjectGuid>
     <RootNamespace>Slamby.Common</RootNamespace>
-    <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'=='' ">..\artifacts\obj\$(MSBuildProjectName)</BaseIntermediateOutputPath>
-    <OutputPath Condition="'$(OutputPath)'=='' ">.\bin\</OutputPath>
+    <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'=='' ">..\..\artifacts\obj</BaseIntermediateOutputPath>
+    <OutputPath Condition="'$(OutputPath)'=='' ">..\..\artifacts\bin\</OutputPath>
     <SccProjectName>SAK</SccProjectName>
     <SccProvider>SAK</SccProvider>
     <SccAuxPath>SAK</SccAuxPath>

--- a/src/Slamby.Common/project.json
+++ b/src/Slamby.Common/project.json
@@ -14,16 +14,12 @@
     "warningsAsErrors": true
   },
   "frameworks": {
-    "netcoreapp1.0": {
+   "netstandard1.6": {
       "imports": [
-        "dotnet5.6",
         "portable-net45+win8"
       ],
       "dependencies": {
-        "Microsoft.NETCore.App": {
-          "version": "1.1.0-preview1-001100-00",
-          "type": "platform"
-        }
+        "NETStandard.Library": "1.6.0"
       }
     }
   },

--- a/src/Slamby.Common/project.json
+++ b/src/Slamby.Common/project.json
@@ -33,7 +33,7 @@
     "Microsoft.Extensions.DependencyInjection": "1.0.0",
     "Microsoft.Extensions.Logging": "1.0.0",
     "Microsoft.Extensions.PlatformAbstractions": "1.0.0",
-    "NEST": "2.1.1",
+    "NEST": "2.4.6",
     "NJsonSchema": "3.3.6061.16591",
     "Slamby.SDK.Net": "1.0.2",
     "System.IO.FileSystem.DriveInfo": "4.0.0-beta-23516"

--- a/src/Slamby.Common/project.json
+++ b/src/Slamby.Common/project.json
@@ -2,35 +2,40 @@
   "version": "1.0.0-*",
   "description": "Slamby.Common Class Library",
   "authors": [ "zsolt.illes" ],
-  "tags": [ "" ],
-  "projectUrl": "",
-  "licenseUrl": "",
+  "packOptions": {
+    "repository": {
+      "url": "https://github.com/slamby/slamby-api",
+      "type": "git"
+    },
+    "licenseUrl": "https://raw.githubusercontent.com/slamby/slamby-api/master/LICENSE",
+    "owners": [ "Zsolt Illes", "Attila Laszlo" ]
+  },
+  "buildOptions": {
+    "warningsAsErrors": true
+  },
   "frameworks": {
-    "dnxcore50": {
+    "netcoreapp1.0": {
+      "imports": [
+        "dotnet5.6",
+        "portable-net45+win8"
+      ],
+      "dependencies": {
+        "Microsoft.NETCore.App": {
+          "version": "1.0.1",
+          "type": "platform"
+        }
+      }
     }
   },
   "dependencies": {
     "FastMember": "1.1.0-beta1",
-    "Microsoft.AspNet.Http.Abstractions": "1.0.0-rc1-final",
-    "Microsoft.AspNet.Mvc.Abstractions": "6.0.0-rc1-final",
-    "Microsoft.AspNet.Mvc.Core": "6.0.0-rc1-final",
-    "Microsoft.CSharp": "4.0.1-beta-23516",
-    "Microsoft.Extensions.DependencyInjection": "1.0.0-rc1-final",
-    "Microsoft.Extensions.Logging": "1.0.0-rc1-final",
-    "Microsoft.Extensions.OptionsModel": "1.0.0-rc1-final",
-    "Microsoft.Extensions.PlatformAbstractions": "1.0.0-rc1-final",
+    "Microsoft.AspNetCore.Mvc": "1.0.1",
+    "Microsoft.Extensions.DependencyInjection": "1.0.0",
+    "Microsoft.Extensions.Logging": "1.0.0",
+    "Microsoft.Extensions.PlatformAbstractions": "1.0.0",
     "NEST": "2.1.1",
-    "NETStandard.Library": "1.5.0-rc3-24015-00",
     "NJsonSchema": "3.3.6061.16591",
     "Slamby.SDK.Net": "1.0.2",
-    "System.Collections": "4.0.11-beta-23516",
-    "System.ComponentModel.Annotations": "4.0.11-beta-23516",
-    "System.Diagnostics.Process": "4.1.0-beta-23516",
-    "System.IO": "4.0.11-beta-23516",
-    "System.IO.FileSystem.DriveInfo": "4.0.0-beta-23516",
-    "System.Linq": "4.0.1-beta-23516",
-    "System.Runtime": "4.0.21-beta-23516",
-    "System.Threading": "4.0.11-beta-23516",
-    "System.Threading.Tasks.Parallel": "4.0.1-beta-23516"
+    "System.IO.FileSystem.DriveInfo": "4.0.0-beta-23516"
   }
 }

--- a/src/Slamby.Common/project.json
+++ b/src/Slamby.Common/project.json
@@ -21,7 +21,7 @@
       ],
       "dependencies": {
         "Microsoft.NETCore.App": {
-          "version": "1.0.1",
+          "version": "1.1.0-preview1-001100-00",
           "type": "platform"
         }
       }
@@ -36,6 +36,6 @@
     "NEST": "2.4.6",
     "NJsonSchema": "3.3.6061.16591",
     "Slamby.SDK.Net": "1.0.2",
-    "System.IO.FileSystem.DriveInfo": "4.0.0-beta-23516"
+    "System.IO.FileSystem.DriveInfo": "4.0.0"
   }
 }

--- a/src/Slamby.Common/project.json
+++ b/src/Slamby.Common/project.json
@@ -24,7 +24,7 @@
     }
   },
   "dependencies": {
-    "FastMember": "1.1.0-beta1",
+    "FastMember": "1.1.0",
     "Microsoft.AspNetCore.Mvc": "1.0.1",
     "Microsoft.Extensions.DependencyInjection": "1.0.0",
     "Microsoft.Extensions.Logging": "1.0.0",

--- a/src/Slamby.Elastic/Queries/IndexQuery.cs
+++ b/src/Slamby.Elastic/Queries/IndexQuery.cs
@@ -209,7 +209,9 @@ namespace Slamby.Elastic.Queries
                     SampleDocument = sampleDynamicDocument,
                     Schema = schema,
                     TagField = tagField,
+#pragma warning disable CS0618 // Type or member is obsolete
                     DBVersion = Common.Constants.DBVersion,
+#pragma warning restore CS0618 // Type or member is obsolete
                     Name = name
                 }
             });

--- a/src/Slamby.Elastic/Slamby.Elastic.xproj
+++ b/src/Slamby.Elastic/Slamby.Elastic.xproj
@@ -8,8 +8,8 @@
   <PropertyGroup Label="Globals">
     <ProjectGuid>f20e2451-7f39-4db0-b06d-ba62d031361d</ProjectGuid>
     <RootNamespace>Slamby.Elastic</RootNamespace>
-    <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'=='' ">..\artifacts\obj\$(MSBuildProjectName)</BaseIntermediateOutputPath>
-    <OutputPath Condition="'$(OutputPath)'=='' ">.\bin\</OutputPath>
+    <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'=='' ">..\..\artifacts\obj</BaseIntermediateOutputPath>
+    <OutputPath Condition="'$(OutputPath)'=='' ">..\..\artifacts\bin\</OutputPath>
     <SccProjectName>SAK</SccProjectName>
     <SccProvider>SAK</SccProvider>
     <SccAuxPath>SAK</SccAuxPath>

--- a/src/Slamby.Elastic/Slamby.Elastic.xproj
+++ b/src/Slamby.Elastic/Slamby.Elastic.xproj
@@ -9,7 +9,7 @@
     <ProjectGuid>f20e2451-7f39-4db0-b06d-ba62d031361d</ProjectGuid>
     <RootNamespace>Slamby.Elastic</RootNamespace>
     <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'=='' ">..\artifacts\obj\$(MSBuildProjectName)</BaseIntermediateOutputPath>
-    <OutputPath Condition="'$(OutputPath)'=='' ">..\artifacts\bin\$(MSBuildProjectName)\</OutputPath>
+    <OutputPath Condition="'$(OutputPath)'=='' ">.\bin\</OutputPath>
     <SccProjectName>SAK</SccProjectName>
     <SccProvider>SAK</SccProvider>
     <SccAuxPath>SAK</SccAuxPath>

--- a/src/Slamby.Elastic/Slamby.Elastic.xproj
+++ b/src/Slamby.Elastic/Slamby.Elastic.xproj
@@ -4,12 +4,11 @@
     <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">14.0.24720</VisualStudioVersion>
     <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
   </PropertyGroup>
-  <Import Project="$(VSToolsPath)\DNX\Microsoft.DNX.Props" Condition="'$(VSToolsPath)' != ''" />
+  <Import Project="$(VSToolsPath)\DotNet\Microsoft.DotNet.Props" Condition="'$(VSToolsPath)' != ''" />
   <PropertyGroup Label="Globals">
     <ProjectGuid>f20e2451-7f39-4db0-b06d-ba62d031361d</ProjectGuid>
     <RootNamespace>Slamby.Elastic</RootNamespace>
-    <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'=='' ">..\..\artifacts\obj</BaseIntermediateOutputPath>
-    <OutputPath Condition="'$(OutputPath)'=='' ">..\..\artifacts\bin\</OutputPath>
+    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
     <SccProjectName>SAK</SccProjectName>
     <SccProvider>SAK</SccProvider>
     <SccAuxPath>SAK</SccAuxPath>
@@ -18,5 +17,5 @@
   <PropertyGroup>
     <SchemaVersion>2.0</SchemaVersion>
   </PropertyGroup>
-  <Import Project="$(VSToolsPath)\DNX\Microsoft.DNX.targets" Condition="'$(VSToolsPath)' != ''" />
+  <Import Project="$(VSToolsPath)\DotNet\Microsoft.DotNet.targets" Condition="'$(VSToolsPath)' != ''" />
 </Project>

--- a/src/Slamby.Elastic/project.json
+++ b/src/Slamby.Elastic/project.json
@@ -2,21 +2,35 @@
   "version": "1.0.0-*",
   "description": "Slamby.Elastic Class Library",
   "authors": [ "Zsolt Illes", "Attila Laszlo" ],
-  "projectUrl": "https://github.com/slamby/slamby-api",
-  "licenseUrl": "https://raw.githubusercontent.com/slamby/slamby-api/master/LICENSE",
+  "packOptions": {
+    "repository": {
+      "url": "https://github.com/slamby/slamby-api",
+      "type": "git"
+    },
+    "licenseUrl": "https://raw.githubusercontent.com/slamby/slamby-api/master/LICENSE",
+    "owners": [ "Zsolt Illes", "Attila Laszlo" ]
+  },
+  "buildOptions": {
+    "warningsAsErrors": true
+  },
   "frameworks": {
-    "dnxcore50": { }
+    "netcoreapp1.0": {
+      "imports": [
+        "dotnet5.6",
+        "portable-net45+win8"
+      ],
+      "dependencies": {
+        "Microsoft.NETCore.App": {
+          "version": "1.0.1",
+          "type": "platform"
+        }
+      }
+    }
   },
   "dependencies": {
-    "System.Collections": "4.0.11-beta-23516",
-    "System.Linq": "4.0.1-beta-23516",
-    "System.Runtime": "4.0.21-beta-23516",
-    "System.Threading": "4.0.11-beta-23516",
     "protobuf-net": "2.1.0-alpha-1",
-    "Elasticsearch.Net": "2.1.1",
-    "NEST": "2.1.1",
-    "Slamby.Common": "1.0.0-*",
-    "System.Threading.Tasks.Parallel": "4.0.1-beta-23516",
-    "System.Threading.Thread": "4.0.0-beta-23516"
+    "Elasticsearch.Net": "2.4.6",
+    "NEST": "2.4.6",
+    "Slamby.Common": "1.0.0-*"
   }
 }

--- a/src/Slamby.Elastic/project.json
+++ b/src/Slamby.Elastic/project.json
@@ -21,7 +21,7 @@
       ],
       "dependencies": {
         "Microsoft.NETCore.App": {
-          "version": "1.0.1",
+          "version": "1.1.0-preview1-001100-00",
           "type": "platform"
         }
       }

--- a/src/Slamby.Elastic/project.json
+++ b/src/Slamby.Elastic/project.json
@@ -24,7 +24,7 @@
     }
   },
   "dependencies": {
-    "protobuf-net": "2.1.0-alpha-1",
+    "protobuf-net": "2.1.0",
     "Elasticsearch.Net": "2.4.6",
     "NEST": "2.4.6",
     "Slamby.Common": "1.0.0-*"

--- a/src/Slamby.Elastic/project.json
+++ b/src/Slamby.Elastic/project.json
@@ -14,16 +14,12 @@
     "warningsAsErrors": true
   },
   "frameworks": {
-    "netcoreapp1.0": {
+  "netstandard1.6": {
       "imports": [
-        "dotnet5.6",
         "portable-net45+win8"
       ],
       "dependencies": {
-        "Microsoft.NETCore.App": {
-          "version": "1.1.0-preview1-001100-00",
-          "type": "platform"
-        }
+        "NETStandard.Library": "1.6.0"
       }
     }
   },

--- a/src/Slamby.Tests/Controllers/DocumentsControllerTests.cs
+++ b/src/Slamby.Tests/Controllers/DocumentsControllerTests.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
-using Microsoft.AspNet.Http;
-using Microsoft.AspNet.Mvc;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
 using Moq;
 using Slamby.API.Controllers;
 using Slamby.API.Models;
@@ -63,8 +63,8 @@ namespace Slamby.Tests.Controllers
             var response = controller.Get("found");
 
             // Assert
-            Assert.IsType<HttpOkObjectResult>(response);
-            Assert.Equal(document, (response as HttpOkObjectResult).Value);
+            Assert.IsType<OkObjectResult>(response);
+            Assert.Equal(document, (response as OkObjectResult).Value);
         }
     }
 }

--- a/src/Slamby.Tests/Helpers/HostUrlHelperTests.cs
+++ b/src/Slamby.Tests/Helpers/HostUrlHelperTests.cs
@@ -1,5 +1,5 @@
 ﻿using FluentAssertions;
-using Microsoft.AspNet.Http;
+using Microsoft.AspNetCore.Http;
 using Moq;
 using Slamby.API.Helpers;
 using Xunit;

--- a/src/Slamby.Tests/Services/ParallelServiceTest.cs
+++ b/src/Slamby.Tests/Services/ParallelServiceTest.cs
@@ -1,11 +1,11 @@
 ﻿using System;
 using FluentAssertions;
-using Microsoft.AspNet.Http;
-using Microsoft.AspNet.Server.Kestrel.Http;
+using Microsoft.AspNetCore.Http;
 using Moq;
 using Slamby.Common.Config;
 using Slamby.Common.Services;
 using Xunit;
+using Microsoft.AspNetCore.Server.Kestrel.Internal.Http;
 
 namespace Slamby.Tests
 {

--- a/src/Slamby.Tests/Slamby.Tests.xproj
+++ b/src/Slamby.Tests/Slamby.Tests.xproj
@@ -4,12 +4,10 @@
     <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">14.0</VisualStudioVersion>
     <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
   </PropertyGroup>
-  <Import Project="$(VSToolsPath)\DNX\Microsoft.DNX.Props" Condition="'$(VSToolsPath)' != ''" />
+  <Import Project="$(VSToolsPath)\DotNet\Microsoft.DotNet.Props" Condition="'$(VSToolsPath)' != ''" />
   <PropertyGroup Label="Globals">
     <ProjectGuid>cb512b48-eeb6-4949-8b81-b7583ddf9720</ProjectGuid>
     <RootNamespace>Slamby.Tests</RootNamespace>
-    <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'=='' ">..\..\artifacts\obj</BaseIntermediateOutputPath>
-    <OutputPath Condition="'$(OutputPath)'=='' ">..\..\artifacts\bin\</OutputPath>
     <SccProjectName>SAK</SccProjectName>
     <SccProvider>SAK</SccProvider>
     <SccAuxPath>SAK</SccAuxPath>
@@ -24,5 +22,5 @@
   <ItemGroup>
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
-  <Import Project="$(VSToolsPath)\DNX\Microsoft.DNX.targets" Condition="'$(VSToolsPath)' != ''" />
+  <Import Project="$(VSToolsPath)\DotNet\Microsoft.DotNet.targets" Condition="'$(VSToolsPath)' != ''" />
 </Project>

--- a/src/Slamby.Tests/Slamby.Tests.xproj
+++ b/src/Slamby.Tests/Slamby.Tests.xproj
@@ -9,7 +9,7 @@
     <ProjectGuid>cb512b48-eeb6-4949-8b81-b7583ddf9720</ProjectGuid>
     <RootNamespace>Slamby.Tests</RootNamespace>
     <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'=='' ">..\..\artifacts\obj\$(MSBuildProjectName)</BaseIntermediateOutputPath>
-    <OutputPath Condition="'$(OutputPath)'=='' ">..\..\artifacts\bin\$(MSBuildProjectName)\</OutputPath>
+    <OutputPath Condition="'$(OutputPath)'=='' ">.\bin\</OutputPath>
     <SccProjectName>SAK</SccProjectName>
     <SccProvider>SAK</SccProvider>
     <SccAuxPath>SAK</SccAuxPath>

--- a/src/Slamby.Tests/Slamby.Tests.xproj
+++ b/src/Slamby.Tests/Slamby.Tests.xproj
@@ -8,8 +8,8 @@
   <PropertyGroup Label="Globals">
     <ProjectGuid>cb512b48-eeb6-4949-8b81-b7583ddf9720</ProjectGuid>
     <RootNamespace>Slamby.Tests</RootNamespace>
-    <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'=='' ">..\..\artifacts\obj\$(MSBuildProjectName)</BaseIntermediateOutputPath>
-    <OutputPath Condition="'$(OutputPath)'=='' ">.\bin\</OutputPath>
+    <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'=='' ">..\..\artifacts\obj</BaseIntermediateOutputPath>
+    <OutputPath Condition="'$(OutputPath)'=='' ">..\..\artifacts\bin\</OutputPath>
     <SccProjectName>SAK</SccProjectName>
     <SccProvider>SAK</SccProvider>
     <SccAuxPath>SAK</SccAuxPath>

--- a/src/Slamby.Tests/project.json
+++ b/src/Slamby.Tests/project.json
@@ -15,7 +15,7 @@
     "warningsAsErrors": true
   },
   "frameworks": {
-    "netcoreapp1.0": {
+    "netcoreapp1.1": {
       "imports": [
         "dotnet5.6",
         "portable-net45+win8"

--- a/src/Slamby.Tests/project.json
+++ b/src/Slamby.Tests/project.json
@@ -2,29 +2,44 @@
   "version": "1.0.0-*",
   "description": "Slamby.Tests Class Library",
   "authors": [ "Zsolt Illes", "Attila Laszlo" ],
-  "projectUrl": "https://github.com/slamby/slamby-api",
-  "licenseUrl": "https://raw.githubusercontent.com/slamby/slamby-api/master/LICENSE",
+  "packOptions": {
+    "repository": {
+      "url": "https://github.com/slamby/slamby-api",
+      "type": "git"
+    },
+    "licenseUrl": "https://raw.githubusercontent.com/slamby/slamby-api/master/LICENSE",
+    "owners": [ "Zsolt Illes", "Attila Laszlo" ]
+  },
+  "testRunner": "xunit",
+  "buildOptions": {
+    "warningsAsErrors": true
+  },
   "frameworks": {
-    "dnxcore50": {
+    "netcoreapp1.0": {
+      "imports": [
+        "dotnet5.6",
+        "portable-net45+win8"
+      ],
+      "dependencies": {
+        "Microsoft.NETCore.App": {
+          "version": "1.0.1",
+          "type": "platform"
+        }
+      }
     }
   },
   "dependencies": {
-    "Microsoft.CSharp": "4.0.1-beta-23516",
-    "System.Collections": "4.0.11-beta-23516",
-    "System.Linq": "4.0.1-beta-23516",
-    "System.Runtime": "4.0.21-beta-23516",
-    "System.Threading": "4.0.11-beta-23516",
     "Slamby.Common": "1.0.0-*",
-    "xunit": "2.1.0",
-    "xunit.runner.dnx": "2.1.0-rc1-build204",
+    "xunit": "2.2.0-beta2-build3300",
+    "dotnet-test-xunit": "2.2.0-preview2-build1029",
     "FluentAssertions": "4.4.0",
     "moq.netcore": "4.4.0-beta8",
-    "Microsoft.AspNet.Http.Abstractions": "1.0.0-rc1-final",
-    "Microsoft.AspNet.Server.Kestrel": "1.0.0-rc1-final",
-    "Slamby.API": "1.0.0-*"
+    "Microsoft.AspNetCore.Http.Abstractions": "1.1.0-preview1-final",
+    "Microsoft.AspNetCore.Server.Kestrel": "1.0.1",
+    "Slamby.API": "1.1.0-*",
+    "System.Diagnostics.TraceSource": "4.3.0-preview1-24530-04"
   },
-  "commands": {
-    "test": "xunit.runner.dnx -xml Slamby.Tests-testresult.xml",
-    "test_ci": "xunit.runner.dnx"
+  "tools": {
+    "dotnet-test-xunit": "2.2.0-preview2-build1029"
   }
 }

--- a/src/Slamby.Tests/project.json
+++ b/src/Slamby.Tests/project.json
@@ -22,7 +22,7 @@
       ],
       "dependencies": {
         "Microsoft.NETCore.App": {
-          "version": "1.0.1",
+          "version": "1.1.0-preview1-001100-00",
           "type": "platform"
         }
       }

--- a/src/global.json
+++ b/src/global.json
@@ -1,6 +1,3 @@
 ﻿{
-  "projects": [ "src", "test" ],
-  "sdk": {
-    "version": "1.0.0-rc1-update1"
-  }
+  "projects": [ "src", "test" ]
 }


### PR DESCRIPTION
I'm proudly presenting the very first PR :sparkles: :star: 

Changes:
- updated projects to .net core 1.0.0 rtm with tooling preview 2

As there were some breaking changes between the versions, I had to change some implementation details:
- in Slamby.Common.DI namespace the Scanner and IServiceCollectionExtensions classes are changed
- in Slamby.API.Helpers.Swashbuckle namespace I had to add the missing annotation attributes.
- the Slamby.API.Helpers.Swashbuckle.RegexModelFilter class renamed to RegexSchemaFilter and now it implements ISchemaFilter
- some other smaller changes

Currently all the tests are green, though the application was not tested at all. Please review my changes, and feel free to comment.

Cheers! :v:
